### PR TITLE
Make fig pure ruby

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -103,7 +103,39 @@ jobs:
           name: fig
           path: pkg/fig-*.gem
 
-  test-gem-installation-linux:
+# Need to figure out how to parameterize the common parts of
+# these jobs and factor out only the differing parts.
+  test-gem-installation-centos:
+    if: false
+    needs: package
+    runs-on: ubuntu-latest
+    container:
+      image: centos:7.9.2009
+    strategy:
+      matrix:
+        ruby:
+          - 3.1.2
+          - 3.3
+    steps:
+      - name: Download gem
+        uses: actions/download-artifact@v4
+        with:
+          name: fig
+          path: .
+
+      - name: Install packages required by setup-ruby action
+        run: |
+          yum install -y libyaml
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+
+      - run: |
+          gem update --system $RUBYGEMS_VER
+          gem install ./fig-*.gem
+
+  test-gem-installation-ubuntu:
     needs: package
     runs-on: ubuntu-latest
     container:
@@ -111,7 +143,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - centos:7.9.2009
           - ubuntu:20.04
           - ubuntu:22.04
           - ubuntu:24.04
@@ -127,15 +158,8 @@ jobs:
 
       - name: Install packages required by setup-ruby action
         run: |
-          case "${{ matrix.os }}" in
-          ubuntu*)
-            apt-get update
-            apt-get install -y libyaml-0-2 openssl
-            ;;
-          centos*)
-            yum install -y libyaml
-            ;;
-          esac
+          apt-get update
+          apt-get install -y libyaml-0-2 openssl nodejs
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,31 +26,26 @@ jobs:
           - macos-14
           - ubuntu-20.04
           - ubuntu-22.04
+        ruby:
+          - 3.1.2
+          - 3.3
         include:
           - os: windows-2022
             platform: x64-mingw32
-            ruby: '3.1.2'
           - os: windows-2022
             platform: x64-mingw-ucrt
-            ruby: '3.1.2'
           - os: macos-14
             platform: x86_64-darwin
-            ruby: '3.1.2'
           - os: macos-14
             platform: arm64-darwin
-            ruby: '3.1.2'
           - os: ubuntu-22.04
             platform: x86_64-linux
-            ruby: '3.1.2'
           - os: ubuntu-22.04
             platform: any
-            ruby: '3.1.2'
           - os: ubuntu-20.04
             platform: x86_64-linux
-            ruby: '3.1.2'
           - os: ubuntu-20.04
             platform: any
-            ruby: '3.1.2'
             
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -57,7 +57,7 @@ jobs:
         run: bundle install
 
       - name: Run tests
-        run: bundle exec rspec
+        run: bundle exec rake rspec
         
       - name: Build the gem
         run: bundle exec rake gem

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,23 +21,34 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - windows-2022
+          - macos-14
+          - ubuntu-20.04
+          - ubuntu-22.04
         include:
-          - os: windows-latest
+          - os: windows-2022
             platform: x64-mingw32
             ruby: '3.1.2'
-          - os: windows-latest
+          - os: windows-2022
             platform: x64-mingw-ucrt
             ruby: '3.1.2'
-          - os: macos-latest
+          - os: macos-14
             platform: x86_64-darwin
             ruby: '3.1.2'
-          - os: macos-latest
+          - os: macos-14
             platform: arm64-darwin
             ruby: '3.1.2'
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             platform: x86_64-linux
             ruby: '3.1.2'
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
+            platform: any
+            ruby: '3.1.2'
+          - os: ubuntu-20.04
+            platform: x86_64-linux
+            ruby: '3.1.2'
+          - os: ubuntu-20.04
             platform: any
             ruby: '3.1.2'
             

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ env:
 
 
 jobs:
-  test:
+  build:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -64,6 +64,32 @@ jobs:
       - name: Run tests
         run: bundle exec rake rspec
         
-      - name: Build the gem
+      - name: Build gem
         run: bundle exec rake gem
 
+      - name: Upload gem
+        uses: actions/upload-artifact@v4
+        with:
+          name: fig
+          path: pkg/fig-*.gem
+
+  test-gem-installation-linux:
+    needs: build
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - centos:7
+          - ubuntu:20.04
+          - ubuntu:22.04
+          - ubuntu:24.04
+          - ubuntu:12.04
+    steps:
+      - name: Download gem
+        uses: actions/download-artifact@v4
+        with:
+          name: fig
+          path: .
+      - run: gem install ./fig-*.gem

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -63,7 +63,35 @@ jobs:
 
       - name: Run tests
         run: bundle exec rake rspec
-        
+
+  # since we are packaging a pure ruby gem, we only need to package
+  # once for each ruby version, not once on every platform.
+  #
+  # and maybe we don't even need to package for each ruby version?
+  package:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby:
+          - 3.1.2
+          - 3.3
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+
+      - run: gem update --system $RUBYGEMS_VER
+
+      - name: Install gem dependencies
+        env:
+          CC: false
+          LD: false
+          CXX: false
+        run: bundle install
+
       - name: Build gem
         run: bundle exec rake gem
 
@@ -74,7 +102,7 @@ jobs:
           path: pkg/fig-*.gem
 
   test-gem-installation-linux:
-    needs: build
+    needs: package
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.os }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -77,7 +77,7 @@ jobs:
       matrix:
         ruby:
           - 3.1.2
-#          - 3.3
+
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -130,7 +130,7 @@ jobs:
           case "${{ matrix.os }}" in
           ubuntu*)
             apt-get update
-            apt-get install -y libyaml-0-2
+            apt-get install -y libyaml-0-2 openssl
             ;;
           centos*)
             yum install -y libyaml

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,8 +12,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  BUNDLER_VER: 2.3.26
-
+  BUNDLER_VER: 2.6.1
+  RUBYGEMS_VER: 3.6.1
 
 jobs:
   build:
@@ -53,6 +53,8 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+
+      - run: gem update --system $RUBYGEMS_VER
 
       - name: Install gem dependencies
         env:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -77,7 +77,7 @@ jobs:
       matrix:
         ruby:
           - 3.1.2
-          - 3.3
+#          - 3.3
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,64 @@
+name: build-and-test
+
+on:
+  push:
+    branches: [ "*" ]
+    tags: [ "v*" ]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.job }}-${{ github.head_ref || github.ref_name }}'
+  cancel-in-progress: true
+
+env:
+  BUNDLER_VER: 2.3.26
+
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            platform: x64-mingw32
+            ruby: '3.1.2'
+          - os: windows-latest
+            platform: x64-mingw-ucrt
+            ruby: '3.1.2'
+          - os: macos-latest
+            platform: x86_64-darwin
+            ruby: '3.1.2'
+          - os: macos-latest
+            platform: arm64-darwin
+            ruby: '3.1.2'
+          - os: ubuntu-latest
+            platform: x86_64-linux
+            ruby: '3.1.2'
+          - os: ubuntu-latest
+            platform: any
+            ruby: '3.1.2'
+          - os: centos7.5
+            platform: x86_64-linux
+            ruby: '3.1.2'
+            
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler: ${{ env.BUNDLER_VER }}
+          bundler-cache: true
+
+      - name: Install gem dependencies
+        run: bundle install
+
+      - name: Run tests
+        run: bundle exec rspec
+        
+      - name: Build the gem
+        run: bundle exec rake gem
+

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -111,7 +111,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - centos:7
+          - centos:7.9.2009
           - ubuntu:20.04
           - ubuntu:22.04
           - ubuntu:24.04
@@ -124,6 +124,18 @@ jobs:
         with:
           name: fig
           path: .
+
+      - name: Install packages required by setup-ruby action
+        run: |
+          case "${{ matrix.os }}" in
+          ubuntu*)
+            apt-get update
+            apt-get install -y libyaml-0-2
+            ;;
+          centos*)
+            yum install -y libyaml
+            ;;
+          esac
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -54,6 +54,10 @@ jobs:
           bundler-cache: true
 
       - name: Install gem dependencies
+        env:
+          CC: false
+          LD: false
+          CXX: false
         run: bundle install
 
       - name: Run tests

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -150,16 +150,16 @@ jobs:
           - 3.1.2
           - 3.3
     steps:
+      - name: Install packages required by github actions
+        run: |
+          apt-get update
+          apt-get install -y libyaml-0-2 openssl nodejs
+
       - name: Download gem
         uses: actions/download-artifact@v4
         with:
           name: fig
           path: .
-
-      - name: Install packages required by setup-ruby action
-        run: |
-          apt-get update
-          apt-get install -y libyaml-0-2 openssl nodejs
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -40,9 +40,6 @@ jobs:
           - os: ubuntu-latest
             platform: any
             ruby: '3.1.2'
-          - os: centos7.5
-            platform: x86_64-linux
-            ruby: '3.1.2'
             
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -116,10 +116,20 @@ jobs:
           - ubuntu:22.04
           - ubuntu:24.04
           - ubuntu:12.04
+        ruby:
+          - 3.1.2
+          - 3.3
     steps:
       - name: Download gem
         uses: actions/download-artifact@v4
         with:
           name: fig
           path: .
-      - run: gem install ./fig-*.gem
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+
+      - run: |
+          gem update --system $RUBYGEMS_VER
+          gem install ./fig-*.gem

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -47,8 +47,6 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler: ${{ env.BUNDLER_VER }}
-          bundler-cache: true
 
       - name: Install gem dependencies
         env:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -115,7 +115,6 @@ jobs:
           - ubuntu:20.04
           - ubuntu:22.04
           - ubuntu:24.04
-          - ubuntu:12.04
         ruby:
           - 3.1.2
           - 3.3

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ env:
   RUBYGEMS_VER: 3.6.1
 
 jobs:
-  build:
+  validate-no-compilation-required:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -71,7 +71,7 @@ jobs:
   #
   # and maybe we don't even need to package for each ruby version?
   package:
-    needs: build
+    needs: validate-no-compilation-required
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/Changes
+++ b/Changes
@@ -1,3 +1,20 @@
+v2.0.0.beta.1 - 2025/2/3
+
+  Announcement:
+
+  - Fig now requires miminum of ruby 3.1.2.
+  - Switch libarchive backend from libarchive-static to ffi-libarchive-binary
+  - Use stdlib for typical package tarball creation.
+
+  Bug Fixes:
+
+  - Abandon use of deprecated APIs.
+
+  Miscellaneous:
+
+  - Add github CI support.
+  - Add build matrix for windows, mac, and linux.
+
 v1.27.29 - 2023/2/7
 
   Bug fix:

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,8 @@ gem 'bcrypt_pbkdf',      '>= 1.1.0'  # Required for ED25519 SSH keys
 gem 'colorize',          '>= 0.5.8'
 gem 'ed25519',           '>= 1.2.4'  # Required for ED25519 SSH keys
 gem 'highline',          '>= 1.6.19'
-gem 'libarchive-static', '>= 1.1.0'
+gem 'ffi-libarchive-binary', '~> 0.3.0'
+gem 'reline', '= 0.5.7'
 gem 'log4r',             '>= 1.1.5'
 gem 'net-ftp',           '>= 0.1.3'
 gem 'net-netrc',         '>= 0.2.2'

--- a/Gemfile
+++ b/Gemfile
@@ -5,15 +5,12 @@ require 'rbconfig'
 
 source 'http://rubygems.org'
 
-( [2, 0, 0] <=> ( RUBY_VERSION.split(".").collect {|x| x.to_i} ) ) <= 0 or
-  abort "Ruby v2.0.0 is required; this is v#{RUBY_VERSION}."
+ruby '>= 3.1.2'
 
 if RUBY_PLATFORM =~ /win32|mingw32/
   gem 'windows-pr',         '1.2.2'
   gem 'win32-security',     '0.1.4'
 end
-
-ruby RUBY_VERSION
 
 # All environments
 gem 'bcrypt_pbkdf',      '>= 1.1.0'  # Required for ED25519 SSH keys

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'net-sftp',          '>= 2.1.2'
 gem 'net-ssh',           '>= 6.1.0'
 gem 'rdoc',              '>= 6.3.1'
 gem 'treetop',           '>= 1.4.14'
+gem 'base64',            '>= 0.1.1'
 
 group :development do
   gem 'bundler',            '>= 1.0.15'

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem 'colorize',          '>= 0.5.8'
 gem 'ed25519',           '>= 1.2.4'  # Required for ED25519 SSH keys
 gem 'highline',          '>= 1.6.19'
 gem 'ffi-libarchive-binary', '~> 0.3.0'
-gem 'reline', '= 0.5.7'
 gem 'log4r',             '>= 1.1.5'
 gem 'net-ftp',           '>= 0.1.3'
 gem 'net-netrc',         '>= 0.2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,7 @@ DEPENDENCIES
   treetop (>= 1.4.14)
 
 RUBY VERSION
-   ruby 3.3.6p108
+   ruby 3.1.2p20
 
 BUNDLED WITH
-   2.3.26
+   2.6.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,30 @@ GEM
   remote: http://rubygems.org/
   specs:
     Platform (0.4.2)
-    bcrypt_pbkdf (1.1.0)
-    colorize (0.8.1)
-    date (3.3.3)
-    diff-lcs (1.5.0)
-    docile (1.4.0)
+    bcrypt_pbkdf (1.1.1)
+    bcrypt_pbkdf (1.1.1-arm64-darwin)
+    colorize (1.1.0)
+    date (3.4.0)
+    diff-lcs (1.5.1)
+    docile (1.4.1)
     ed25519 (1.3.0)
-    highline (2.1.0)
-    libarchive-static (1.1.0)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
+    ffi-libarchive (1.1.14)
+      ffi (~> 1.0)
+    ffi-libarchive-binary (0.3.0-arm64-darwin)
+      bundler (~> 2.3, >= 2.3.22)
+      ffi (~> 1.0)
+      ffi-libarchive (~> 1.0)
+      rake (~> 13.0)
+    ffi-libarchive-binary (0.3.0-x86_64-linux)
+      bundler (~> 2.3, >= 2.3.22)
+      ffi (~> 1.0)
+      ffi-libarchive (~> 1.0)
+      rake (~> 13.0)
+    highline (3.1.1)
+      reline
+    io-console (0.7.2)
     log4r (1.1.10)
     net-ftp (0.2.0)
       net-protocol
@@ -24,6 +40,8 @@ GEM
     polyglot (0.3.5)
     rake (13.0.6)
     rdoc (6.3.3)
+    reline (0.5.7)
+      io-console (~> 0.5)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -50,6 +68,7 @@ GEM
       polyglot (~> 0.3)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES
@@ -57,8 +76,8 @@ DEPENDENCIES
   bundler (>= 1.0.15)
   colorize (>= 0.5.8)
   ed25519 (>= 1.2.4)
+  ffi-libarchive-binary (~> 0.3.0)
   highline (>= 1.6.19)
-  libarchive-static (>= 1.1.0)
   log4r (>= 1.1.5)
   net-ftp (>= 0.1.3)
   net-netrc (>= 0.2.2)
@@ -66,6 +85,7 @@ DEPENDENCIES
   net-ssh (>= 6.1.0)
   rake (>= 0.8.7)
   rdoc (>= 6.3.1)
+  reline (= 0.5.7)
   rspec (~> 3)
   simplecov (>= 0.6.2)
   simplecov-html (>= 0.5.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,15 +4,23 @@ GEM
     Platform (0.4.2)
     bcrypt_pbkdf (1.1.1)
     bcrypt_pbkdf (1.1.1-arm64-darwin)
+    bcrypt_pbkdf (1.1.1-x64-mingw-ucrt)
     colorize (1.1.0)
     date (3.4.0)
     diff-lcs (1.5.1)
     docile (1.4.1)
     ed25519 (1.3.0)
     ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x64-mingw-ucrt)
+    ffi (1.17.0-x86_64-linux-gnu)
     ffi-libarchive (1.1.14)
       ffi (~> 1.0)
     ffi-libarchive-binary (0.3.0-arm64-darwin)
+      bundler (~> 2.3, >= 2.3.22)
+      ffi (~> 1.0)
+      ffi-libarchive (~> 1.0)
+      rake (~> 13.0)
+    ffi-libarchive-binary (0.3.0-x64-mingw-ucrt)
       bundler (~> 2.3, >= 2.3.22)
       ffi (~> 1.0)
       ffi-libarchive (~> 1.0)
@@ -69,6 +77,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
+  x64-mingw-ucrt
   x86_64-linux
 
 DEPENDENCIES
@@ -91,7 +100,7 @@ DEPENDENCIES
   treetop (>= 1.4.14)
 
 RUBY VERSION
-   ruby 3.1.2p20
+   ruby 3.3.6p108
 
 BUNDLED WITH
    2.3.26

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,6 @@ GEM
     docile (1.4.1)
     ed25519 (1.3.0)
     ffi (1.17.0-arm64-darwin)
-    ffi (1.17.0-x86_64-linux-gnu)
     ffi-libarchive (1.1.14)
       ffi (~> 1.0)
     ffi-libarchive-binary (0.3.0-arm64-darwin)
@@ -69,6 +68,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -85,7 +85,6 @@ DEPENDENCIES
   net-ssh (>= 6.1.0)
   rake (>= 0.8.7)
   rdoc (>= 6.3.1)
-  reline (= 0.5.7)
   rspec (~> 3)
   simplecov (>= 0.6.2)
   simplecov-html (>= 0.5.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     Platform (0.4.2)
+    base64 (0.1.1)
     bcrypt_pbkdf (1.1.1)
     bcrypt_pbkdf (1.1.1-arm64-darwin)
     bcrypt_pbkdf (1.1.1-x64-mingw-ucrt)
@@ -81,6 +82,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  base64 (>= 0.1.1)
   bcrypt_pbkdf (>= 1.1.0)
   bundler (>= 1.0.15)
   colorize (>= 0.5.8)

--- a/Rakefile
+++ b/Rakefile
@@ -46,7 +46,7 @@ def main()
       'Fig is a utility for configuring environments and managing dependencies across a team of developers.'
     gemspec.description =
       "Fig is a utility for configuring environments and managing dependencies across a team of developers. Given a list of packages and a command to run, Fig builds environment variables named in those packages (e.g., CLASSPATH), then executes the command in that environment. The caller's environment is not affected."
-    gemspec.license     = 'BSD'
+    gemspec.license     = 'BSD-3-Clause'
 
     add_dependencies(gemspec) # From inc/build_utilities above.
 

--- a/Rakefile
+++ b/Rakefile
@@ -235,8 +235,8 @@ end
 
 def push_to_rubygems(version)
   print "Checking to see if pkg/fig-#{version}.gem exists... "
-  if File.exists?("pkg/fig-#{version}.gem")
-    puts 'File exists.'
+  if File.exist?("pkg/fig-#{version}.gem")
+    puts 'File.exist.'
     puts "Pushing pkg/fig-#{version}.gem to rubygems.org."
     puts %x{gem push pkg/fig-#{version}.gem 2>&1}
 

--- a/inc/build_utilities.rb
+++ b/inc/build_utilities.rb
@@ -10,7 +10,7 @@ def add_dependencies(gemspec)
   gemspec.add_dependency 'colorize',          '>= 0.5.8'
   gemspec.add_dependency 'highline',          '>= 1.6.19'
   gemspec.add_dependency 'json',              '>= 1.8'
-  gemspec.add_dependency 'libarchive-static', '>= 1.0.5'
+  gemspec.add_dependency 'ffi-libarchive-binary', '~> 0.3.0'
   gemspec.add_dependency 'log4r',             '>= 1.1.5'
   gemspec.add_dependency 'net-netrc',         '>= 0.2.2'
   gemspec.add_dependency 'net-sftp',          '>= 2.1.2'

--- a/inc/build_utilities.rb
+++ b/inc/build_utilities.rb
@@ -7,16 +7,20 @@
 require 'rbconfig'
 
 def add_dependencies(gemspec)
+  #gemspec.add_dependency 'bcrypt_pbkdf', '>= 1.1.0'
   gemspec.add_dependency 'colorize',          '>= 0.5.8'
+  #gemspec.add_dependency 'ed25519', '>= 1.2.4'
   gemspec.add_dependency 'highline',          '>= 1.6.19'
-  gemspec.add_dependency 'json',              '>= 1.8'
+  gemspec.add_dependency 'json',              '>= 1.8' # why is this here and not Gemfile
   gemspec.add_dependency 'ffi-libarchive-binary', '~> 0.3.0'
   gemspec.add_dependency 'log4r',             '>= 1.1.5'
+  #gemspec.add_dependency 'net-ftp', '>= 0.1.3'
   gemspec.add_dependency 'net-netrc',         '>= 0.2.2'
   gemspec.add_dependency 'net-sftp',          '>= 2.1.2'
-  gemspec.add_dependency 'net-ssh',           '>= 5.0.2'
-  gemspec.add_dependency 'rdoc',              '~> 4.3.0'
+  gemspec.add_dependency 'net-ssh',           '>= 6.1.0'
+  gemspec.add_dependency 'rdoc',              '>= 6.3.1'
   gemspec.add_dependency 'treetop',           '>= 1.4.14'
+  #gemspec.add_dependency 'base64', '>= 0.1.1'
 
   gemspec.add_development_dependency 'bundler',         '>= 1.0.15'
   gemspec.add_development_dependency 'rake',            '>= 0.8.7'
@@ -24,7 +28,5 @@ def add_dependencies(gemspec)
   gemspec.add_development_dependency 'simplecov',       '>= 0.6.2'
   gemspec.add_development_dependency 'simplecov-html',  '>= 0.5.3'
 
-  gemspec.required_ruby_version = '>= 2.0.0'
-
-  return
+  gemspec.required_ruby_version = '>= 3.1.2'
 end

--- a/lib/fig.rb
+++ b/lib/fig.rb
@@ -1,5 +1,5 @@
 # coding: utf-8
 
 module Fig
-  VERSION = '1.27.29'
+  VERSION = '2.0.0.beta.1'.freeze
 end

--- a/lib/fig/command.rb
+++ b/lib/fig/command.rb
@@ -1,5 +1,6 @@
 # coding: utf-8
 
+require 'bundler/setup'
 require 'fileutils'
 require 'net/ftp'
 require 'set'

--- a/lib/fig/figrc.rb
+++ b/lib/fig/figrc.rb
@@ -61,7 +61,7 @@ class Fig::FigRC
 
   def self.handle_figrc(configuration)
     user_figrc_path = File.expand_path('~/.figrc')
-    return if not File.exists? user_figrc_path
+    return if not File.exist? user_figrc_path
 
     begin
       configuration_text = File::open(user_figrc_path).read

--- a/lib/fig/operating_system.rb
+++ b/lib/fig/operating_system.rb
@@ -4,7 +4,7 @@ require 'cgi'
 require 'fileutils'
 # Must specify absolute path of ::Archive when using
 # this module to avoid conflicts with Fig::Statement::Archive
-require 'libarchive_ruby'
+require 'ffi-libarchive-binary'
 require 'rbconfig'
 require 'set'
 

--- a/lib/fig/operating_system.rb
+++ b/lib/fig/operating_system.rb
@@ -221,7 +221,7 @@ class Fig::OperatingSystem
   def unpack_archive(directory, archive_path)
     FileUtils.mkdir_p directory
     Dir.chdir(directory) do
-      if ! File.exists? archive_path
+      if ! File.exist? archive_path
         raise Fig::RepositoryError.new "#{archive_path} does not exist."
       end
 

--- a/lib/fig/repository.rb
+++ b/lib/fig/repository.rb
@@ -354,7 +354,7 @@ class Fig::Repository
     FileUtils.mv temporary_package, package_directory
 
     runtime_directory = package.runtime_directory
-    if File.exists? temporary_runtime
+    if File.exist? temporary_runtime
       FileUtils.mkdir_p File.dirname(runtime_directory)
       FileUtils.mv temporary_runtime, runtime_directory
     else

--- a/lib/fig/repository_package_publisher.rb
+++ b/lib/fig/repository_package_publisher.rb
@@ -671,7 +671,7 @@ class Fig::RepositoryPackagePublisher
           expansion_happened = true; published_package.runtime_directory
         }
 
-        if expansion_happened && ! File.exists?(expanded_value) && ! File.symlink?(expanded_value)
+        if expansion_happened && ! File.exist?(expanded_value) && ! File.symlink?(expanded_value)
           Fig::Logging.warn(
             %Q<The #{statement.name} variable points to a path that does not exist (#{expanded_value}); retrieve statements that are active when this package is included may fail.>
           )

--- a/lib/fig/runtime_environment.rb
+++ b/lib/fig/runtime_environment.rb
@@ -503,7 +503,7 @@ class Fig::RuntimeEnvironment
   def check_source_existence(
     variable_name, variable_value, package, backtrace
   )
-    return if File.exists?(variable_value) || File.symlink?(variable_value)
+    return if File.exist?(variable_value) || File.symlink?(variable_value)
 
     raise_repository_error(
       %Q<In #{package}, the #{variable_name} variable points to a path that does not exist ("#{variable_value}", after expansion).>,

--- a/lib/fig/update_lock.rb
+++ b/lib/fig/update_lock.rb
@@ -63,7 +63,7 @@ class Fig::UpdateLock
 
     # Yes, there's a race condition here, but with the way Windows file locking
     # works, it's better than a boot to the head.
-    if ! File.exists? lock_file
+    if ! File.exist? lock_file
       created_file = File.new(lock_file, 'w')
       created_file.close
     end

--- a/spec/command/publishing_spec.rb
+++ b/spec/command/publishing_spec.rb
@@ -301,8 +301,8 @@ describe 'Fig' do
           end
         END
         fig(%w<--publish foo/1.2.3>, input)
-        fail unless File.exists? FIG_HOME + '/packages/foo/1.2.3/.fig'
-        fail unless File.exists? FIG_REMOTE_DIR + '/foo/1.2.3/.fig'
+        fail unless File.exist? FIG_HOME + '/packages/foo/1.2.3/.fig'
+        fail unless File.exist? FIG_REMOTE_DIR + '/foo/1.2.3/.fig'
         fig(%w<--update --include foo/1.2.3 --get FOO>)[0].should == 'SHEEP'
 
         input = <<-END
@@ -348,7 +348,7 @@ describe 'Fig' do
         fig(%w<--publish-local foo/1.2.3>, input)
 
         a_file_published = "#{FIG_HOME}/runtime/foo/1.2.3/a-file.txt"
-        fail unless File.exists? a_file_published
+        fail unless File.exist? a_file_published
 
         File.unlink a_file_unpublished
 
@@ -365,8 +365,8 @@ describe 'Fig' do
 
         another_file_published =
           "#{FIG_HOME}/runtime/foo/1.2.3/another-file.txt"
-        fail unless File.exists? another_file_published
-        fail if File.exists? a_file_published # This is the real test.
+        fail unless File.exist? another_file_published
+        fail if File.exist? a_file_published # This is the real test.
       end
 
       describe 'with both a package.fig file in the current directory and an environment variable option' do
@@ -496,8 +496,8 @@ describe 'Fig' do
           end
         END
         fig(%w<--publish foo/1.2.3>, input)
-        fail unless File.exists? FIG_HOME + '/packages/foo/1.2.3/.fig'
-        fail unless File.exists? FIG_REMOTE_DIR + '/foo/1.2.3/.fig'
+        fail unless File.exist? FIG_HOME + '/packages/foo/1.2.3/.fig'
+        fail unless File.exist? FIG_REMOTE_DIR + '/foo/1.2.3/.fig'
         fig(%w<--update --include foo/1.2.3 -- hello.bat>)[0].should == 'bar'
       end
 
@@ -508,8 +508,8 @@ describe 'Fig' do
           fail unless system "chmod +x #{CURRENT_DIRECTORY}/bin/hello.bat"
         end
         fig(%w<--publish foo/1.2.3 --resource bin/hello.bat --append PATH=@/bin>)
-        fail unless File.exists? FIG_HOME + '/packages/foo/1.2.3/.fig'
-        fail unless File.exists? FIG_REMOTE_DIR + '/foo/1.2.3/.fig'
+        fail unless File.exist? FIG_HOME + '/packages/foo/1.2.3/.fig'
+        fail unless File.exist? FIG_REMOTE_DIR + '/foo/1.2.3/.fig'
         fig(%w<--update --include foo/1.2.3 -- hello.bat>)[0].should == 'bar'
       end
 
@@ -529,7 +529,7 @@ describe 'Fig' do
             --append PATH=@/bin
           >
         )
-        fail if File.exists? FIG_REMOTE_DIR + '/foo/1.2.3/.fig'
+        fail if File.exist? FIG_REMOTE_DIR + '/foo/1.2.3/.fig'
         fig(
           %w<--update-if-missing --include foo/1.2.3 -- hello.bat>
         )[0].should == 'bar'
@@ -564,7 +564,7 @@ describe 'Fig' do
             --append PATH=@/bin
           >
         )
-        fail if File.exists? FIG_REMOTE_DIR + '/foo/1.2.3/.fig'
+        fail if File.exist? FIG_REMOTE_DIR + '/foo/1.2.3/.fig'
         fig(
           %w<
             --update-if-missing
@@ -586,7 +586,7 @@ describe 'Fig' do
             --append PATH=@/bin
           >
         )
-        fail if File.exists? FIG_REMOTE_DIR + '/foo/1.2.3/.fig'
+        fail if File.exist? FIG_REMOTE_DIR + '/foo/1.2.3/.fig'
         fig(%w<--update-if-missing --include foo/1.2.3 -- hello.bat>)[0].should ==
           'cheese'
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,9 +3,6 @@
 ( [2, 0, 0] <=> ( RUBY_VERSION.split(".").collect {|x| x.to_i} ) ) <= 0 or
   abort "Ruby v2.0.0 is required; this is v#{RUBY_VERSION}."
 
-$LOAD_PATH.unshift(File.dirname(__FILE__))
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
-
 if ENV['FIG_COVERAGE']
   require 'simplecov' # note that .simplecov will be loaded here.
 


### PR DESCRIPTION
There's a lot in here, but the big hitters are:
- replace libarchive-static with ff-libarchive-binary
- replace tarball creation with same tooling used by gem creation
- small ruby modernizations
- add GHA CI to validate that the gem can be used without compilation on all target platforms
- bump minimal ruby version to 3.1.x
- BUMP THE MAJOR VERSION TO 2

The primary intent is that installing and using fig should not require a C toolchain on supported platforms.  If we need to support an additional platform, we can work with the active maintainers of [`ffi-libarchive-binary`](https://github.com/fontist/ffi-libarchive-binary/) to add that binary support.