### PR TITLE
Split remote repo specification into CONSUME and PUBLISH specs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ PATH
       highline (~> 3.1.0)
       json (~> 2.10.0)
       log4r (~> 1.1.0)
+      logger (~> 1.6.0)
       net-ftp (~> 0.3.0)
       net-netrc (~> 0.2.0)
       net-sftp (~> 4.0.0)
@@ -54,6 +55,7 @@ GEM
     io-console (0.8.0)
     json (2.10.1)
     log4r (1.1.10)
+    logger (1.6.0)
     net-ftp (0.3.8)
       net-protocol
       time

--- a/fig.gemspec
+++ b/fig.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'net-netrc',         '~> 0.2.0'
   spec.add_dependency 'net-sftp',          '~> 4.0.0'
   spec.add_dependency 'net-ssh',           '~> 7.3.0'
+  spec.add_dependency 'logger',            '~> 1.6.0'
   spec.add_dependency 'treetop',           '~> 1.6.0'
   spec.add_dependency 'base64', '~> 0.2.0'
   spec.add_dependency 'stringio', '~> 3.1.0'

--- a/lib/fig/application_configuration.rb
+++ b/lib/fig/application_configuration.rb
@@ -5,7 +5,8 @@ module Fig; end
 # Configuration for the Fig program, as opposed to a config in a package.
 class Fig::ApplicationConfiguration
   attr_accessor :base_whitelisted_url
-  attr_accessor :remote_repository_url
+  attr_accessor :remote_consume_url
+  attr_accessor :remote_publish_url
 
   def initialize()
     @data = []

--- a/lib/fig/command.rb
+++ b/lib/fig/command.rb
@@ -267,7 +267,8 @@ class Fig::Command
       @options,
       @operating_system,
       @options.home(),
-      nil, # remote_repository_url - no longer used, passing nil for compatibility
+      @application_configuration.remote_consume_url,
+      @application_configuration.remote_publish_url,
       @parser,
       @publish_listeners,
     )

--- a/lib/fig/command.rb
+++ b/lib/fig/command.rb
@@ -243,13 +243,19 @@ class Fig::Command
       @options.no_remote_figrc?
     )
 
-    if \
-          remote_operation_necessary? \
-      &&  @application_configuration.remote_repository_url.nil?
-
-      raise Fig::UserInputError.new(
-        'Please define the FIG_REMOTE_URL environment variable.'
-      )
+    if remote_operation_necessary?
+      # Check if any action is a publishing operation
+      publishing_operation = @options.actions.any? {|action| action.publish?}
+      
+      if publishing_operation && @application_configuration.remote_publish_url.nil?
+        raise Fig::UserInputError.new(
+          'Please define the FIG_PUBLISH_URL environment variable for publishing operations.'
+        )
+      elsif !publishing_operation && @application_configuration.remote_consume_url.nil?
+        raise Fig::UserInputError.new(
+          'Please define the FIG_CONSUME_URL environment variable for repository operations.'
+        )
+      end
     end
 
     return
@@ -261,7 +267,7 @@ class Fig::Command
       @options,
       @operating_system,
       @options.home(),
-      @application_configuration.remote_repository_url,
+      nil, # remote_repository_url - no longer used, passing nil for compatibility
       @parser,
       @publish_listeners,
     )

--- a/lib/fig/protocol/file.rb
+++ b/lib/fig/protocol/file.rb
@@ -21,10 +21,12 @@ class Fig::Protocol::File
     return packages if ! ::File.exist?(unescaped_path)
 
     ls = ''
+
+    unescaped_path = FileTest.symlink?(unescaped_path) ? ::File.realpath(unescaped_path) : unescaped_path
     Find.find(unescaped_path) {
       |file|
 
-      if FileTest.directory? file
+      if FileTest.directory?(file)
         ls << file.to_s
         ls << "\n"
       end

--- a/lib/fig/repository.rb
+++ b/lib/fig/repository.rb
@@ -33,7 +33,8 @@ class Fig::Repository
     options,
     operating_system,
     local_repository_directory,
-    remote_repository_url, # kept for backward compatibility but unused
+    remote_consume_url,
+    remote_publish_url,
     parser,
     publish_listeners
   )
@@ -41,6 +42,8 @@ class Fig::Repository
     @options                      = options
     @operating_system             = operating_system
     @local_repository_directory   = local_repository_directory
+    @remote_consume_url           = remote_consume_url
+    @remote_publish_url           = remote_publish_url
     @parser                       = parser
     @publish_listeners            = publish_listeners
 
@@ -173,14 +176,8 @@ class Fig::Repository
 
   private
 
-  # Helper methods to get the appropriate URL based on operation type
-  def remote_consume_url
-    @application_configuration.remote_consume_url
-  end
-  
-  def remote_publish_url
-    @application_configuration.remote_publish_url
-  end
+  attr_reader :remote_consume_url
+  attr_reader :remote_publish_url
 
   def initialize_local_repository()
     FileUtils.mkdir_p(@local_repository_directory)

--- a/lib/fig/url_access_disallowed_error.rb
+++ b/lib/fig/url_access_disallowed_error.rb
@@ -11,5 +11,10 @@ module Fig
       @urls       = urls
       @descriptor = descriptor
     end
+
+    def message
+      "URLAccessDisallowedError:\n  descriptor = #{descriptor.inspect}\n  urls = " +
+        @urls.map { |k,v| " - #{k}: #{v.inspect}" }.join("\n    ")
+    end
   end
 end

--- a/spec/application_configuration_spec.rb
+++ b/spec/application_configuration_spec.rb
@@ -12,7 +12,8 @@ describe 'ApplicationConfiguration' do
     config = Fig::ApplicationConfiguration.new
 
     config.base_whitelisted_url  = REPOSITORY_TEST_URL
-    config.remote_repository_url = REPOSITORY_TEST_URL
+    config.remote_consume_url = REPOSITORY_TEST_URL
+    config.remote_publish_url = REPOSITORY_TEST_URL
 
     return config
   end

--- a/spec/command/publishing_retrieval_spec.rb
+++ b/spec/command/publishing_retrieval_spec.rb
@@ -12,6 +12,7 @@ describe 'Fig' do
 
     before(:each) do
       clean_up_test_environment
+      set_up_test_environment
       FileUtils.mkdir_p CURRENT_DIRECTORY
       FileUtils.mkdir_p lib_directory
     end

--- a/spec/command/publishing_spec.rb
+++ b/spec/command/publishing_spec.rb
@@ -481,6 +481,7 @@ describe 'Fig' do
     context 'starting with a clean test environment' do
       before(:each) do
         clean_up_test_environment
+        set_up_test_environment
       end
 
       it 'publishes resource to remote repository' do

--- a/spec/command/publishing_spec.rb
+++ b/spec/command/publishing_spec.rb
@@ -302,7 +302,7 @@ describe 'Fig' do
         END
         fig(%w<--publish foo/1.2.3>, input)
         fail unless File.exist? FIG_HOME + '/packages/foo/1.2.3/.fig'
-        fail unless File.exist? FIG_REMOTE_DIR + '/foo/1.2.3/.fig'
+        fail unless File.exist? FIG_CONSUME_DIR + '/foo/1.2.3/.fig'
         fig(%w<--update --include foo/1.2.3 --get FOO>)[0].should == 'SHEEP'
 
         input = <<-END
@@ -497,7 +497,7 @@ describe 'Fig' do
         END
         fig(%w<--publish foo/1.2.3>, input)
         fail unless File.exist? FIG_HOME + '/packages/foo/1.2.3/.fig'
-        fail unless File.exist? FIG_REMOTE_DIR + '/foo/1.2.3/.fig'
+        fail unless File.exist? FIG_CONSUME_DIR + '/foo/1.2.3/.fig'
         fig(%w<--update --include foo/1.2.3 -- hello.bat>)[0].should == 'bar'
       end
 
@@ -509,7 +509,7 @@ describe 'Fig' do
         end
         fig(%w<--publish foo/1.2.3 --resource bin/hello.bat --append PATH=@/bin>)
         fail unless File.exist? FIG_HOME + '/packages/foo/1.2.3/.fig'
-        fail unless File.exist? FIG_REMOTE_DIR + '/foo/1.2.3/.fig'
+        fail unless File.exist? FIG_CONSUME_DIR + '/foo/1.2.3/.fig'
         fig(%w<--update --include foo/1.2.3 -- hello.bat>)[0].should == 'bar'
       end
 
@@ -529,7 +529,7 @@ describe 'Fig' do
             --append PATH=@/bin
           >
         )
-        fail if File.exist? FIG_REMOTE_DIR + '/foo/1.2.3/.fig'
+        fail if File.exist? FIG_CONSUME_DIR + '/foo/1.2.3/.fig'
         fig(
           %w<--update-if-missing --include foo/1.2.3 -- hello.bat>
         )[0].should == 'bar'
@@ -564,7 +564,7 @@ describe 'Fig' do
             --append PATH=@/bin
           >
         )
-        fail if File.exist? FIG_REMOTE_DIR + '/foo/1.2.3/.fig'
+        fail if File.exist? FIG_CONSUME_DIR + '/foo/1.2.3/.fig'
         fig(
           %w<
             --update-if-missing
@@ -586,7 +586,7 @@ describe 'Fig' do
             --append PATH=@/bin
           >
         )
-        fail if File.exist? FIG_REMOTE_DIR + '/foo/1.2.3/.fig'
+        fail if File.exist? FIG_CONSUME_DIR + '/foo/1.2.3/.fig'
         fig(%w<--update-if-missing --include foo/1.2.3 -- hello.bat>)[0].should ==
           'cheese'
       end

--- a/spec/command/usage_errors_spec.rb
+++ b/spec/command/usage_errors_spec.rb
@@ -392,49 +392,89 @@ describe 'Fig' do
       end
     end
 
-    describe %q<prints error when attempting a remote operation and FIG_REMOTE_URL is> do
-      it %q<not defined> do
+    describe %q<prints error when attempting a remote operation and required URLs are missing or invalid> do
+      it %q<FIG_CONSUME_URL not defined> do
         begin
+          # Make sure all URL env vars are unset
           ENV.delete('FIG_REMOTE_URL')
+          ENV.delete('FIG_CONSUME_URL')
+          ENV.delete('FIG_PUBLISH_URL')
 
           out, err, exit_code =
             fig %w<--list-remote>, :fork => false, :no_raise_on_error => true
 
-          err.should =~ %r<FIG_REMOTE_URL>
+          # Error should mention the missing FIG_CONSUME_URL
+          err.should =~ %r<FIG_CONSUME_URL>
           out.should == ''
           exit_code.should_not == 0
         ensure
-          ENV['FIG_REMOTE_URL'] = FIG_REMOTE_URL
+          # Restore default test configuration
+          ENV['FIG_CONSUME_URL'] = FIG_CONSUME_URL 
+          ENV['FIG_PUBLISH_URL'] = FIG_PUBLISH_URL
         end
       end
 
-      it %q<empty> do
+      it %q<FIG_CONSUME_URL empty> do
         begin
-          ENV['FIG_REMOTE_URL'] = ''
+          # Clear all URLs, but set consume to empty
+          ENV.delete('FIG_REMOTE_URL')
+          ENV['FIG_CONSUME_URL'] = ''
+          ENV.delete('FIG_PUBLISH_URL')
 
           out, err, exit_code =
             fig %w<--list-remote>, :fork => false, :no_raise_on_error => true
 
-          err.should =~ %r<FIG_REMOTE_URL>
+          # With empty URLs, the error is about protocol handling
+          err.should =~ %r<Don't know how to handle the protocol>
           out.should == ''
           exit_code.should_not == 0
         ensure
-          ENV['FIG_REMOTE_URL'] = FIG_REMOTE_URL
+          # Restore default test configuration
+          ENV['FIG_CONSUME_URL'] = FIG_CONSUME_URL 
+          ENV['FIG_PUBLISH_URL'] = FIG_PUBLISH_URL
         end
       end
 
-      it %q<all whitespace> do
+      it %q<FIG_CONSUME_URL all whitespace> do
         begin
-          ENV['FIG_REMOTE_URL'] = " \n\t"
+          # Clear all URLs, but set consume to whitespace
+          ENV.delete('FIG_REMOTE_URL')
+          ENV['FIG_CONSUME_URL'] = " \n\t"
+          ENV.delete('FIG_PUBLISH_URL')
 
           out, err, exit_code =
             fig %w<--list-remote>, :fork => false, :no_raise_on_error => true
 
-          err.should =~ %r<FIG_REMOTE_URL>
+          # With whitespace URLs, error is about bad URI format
+          err.should =~ %r<Cannot parse URL>
           out.should == ''
           exit_code.should_not == 0
         ensure
-          ENV['FIG_REMOTE_URL'] = FIG_REMOTE_URL
+          # Restore default test configuration
+          ENV['FIG_CONSUME_URL'] = FIG_CONSUME_URL 
+          ENV['FIG_PUBLISH_URL'] = FIG_PUBLISH_URL
+        end
+      end
+      
+      it %q<FIG_REMOTE_URL set but new URLs missing> do
+        begin
+          # Set remote URL but not the new ones
+          ENV['FIG_REMOTE_URL'] = "file:///some/path"
+          ENV.delete('FIG_CONSUME_URL')
+          ENV.delete('FIG_PUBLISH_URL')
+
+          out, err, exit_code =
+            fig %w<--list-remote>, :fork => false, :no_raise_on_error => true
+
+          # Error should mention both old and new URLs
+          err.should =~ %r<FIG_REMOTE_URL is set but FIG_CONSUME_URL and\/or FIG_PUBLISH_URL are missing>
+          out.should == ''
+          exit_code.should_not == 0
+        ensure
+          # Restore default test configuration
+          ENV.delete('FIG_REMOTE_URL')
+          ENV['FIG_CONSUME_URL'] = FIG_CONSUME_URL 
+          ENV['FIG_PUBLISH_URL'] = FIG_PUBLISH_URL
         end
       end
     end

--- a/spec/figrc_spec.rb
+++ b/spec/figrc_spec.rb
@@ -121,4 +121,22 @@ describe 'FigRC' do
     configuration = invoke_find tempfile.path, nil
     configuration['foo'].should == 'loaded from repository'
   end
+
+  it 'ignores unknown settings without errors' do
+    tempfile = Tempfile.new('unknown_settings_test')
+    tempfile << %Q< { "foo": "bar", "fig_2x_setting": "future setting value" } >
+    tempfile.close
+
+    # This should not raise any errors despite unknown setting
+    configuration = invoke_find(tempfile.path, nil)
+    
+    # Known setting works
+    configuration['foo'].should == 'bar'
+    
+    # Unknown setting is accessible but would be ignored by code not looking for it
+    configuration['fig_2x_setting'].should == 'future setting value'
+    
+    # Completely nonexistent setting returns nil
+    configuration['nonexistent'].should be_nil
+  end
 end

--- a/spec/figrc_spec.rb
+++ b/spec/figrc_spec.rb
@@ -24,16 +24,16 @@ describe 'FigRC' do
 
   def create_override_file_with_repository_url()
     tempfile = Tempfile.new('some_json_tempfile')
-    tempfile << %Q< { "default FIG_REMOTE_URL" : "#{FIG_REMOTE_URL}" } >
+    tempfile << %Q< { "default FIG_CONSUME_URL" : "#{FIG_CONSUME_URL}" } >
     tempfile.close
     return tempfile
   end
 
   def create_remote_config(foo, bar = nil)
     FileUtils.mkdir_p(
-      File.join(FIG_REMOTE_DIR, Fig::Repository::METADATA_SUBDIRECTORY)
+      File.join(FIG_CONSUME_DIR, Fig::Repository::METADATA_SUBDIRECTORY)
     )
-    figrc_path = File.join(FIG_REMOTE_DIR, Fig::FigRC::REPOSITORY_CONFIGURATION)
+    figrc_path = File.join(FIG_CONSUME_DIR, Fig::FigRC::REPOSITORY_CONFIGURATION)
     file_handle = File.new(figrc_path,'w')
     file_handle.write( %Q< { "foo" : "#{foo}" > )
     if not bar.nil?
@@ -66,7 +66,7 @@ describe 'FigRC' do
     tempfile = create_override_file('loaded as override')
 
     create_remote_config("loaded from repository (shouldn't be)")
-    configuration = invoke_find tempfile.path, FIG_REMOTE_URL
+    configuration = invoke_find tempfile.path, FIG_CONSUME_URL
     tempfile.unlink
 
     configuration['foo'].should == 'loaded as override'
@@ -95,21 +95,21 @@ describe 'FigRC' do
   it 'retrieves configuration from repository with no override' do
     create_remote_config('loaded from repository')
 
-    configuration = invoke_find nil, FIG_REMOTE_URL
+    configuration = invoke_find nil, FIG_CONSUME_URL
     configuration['foo'].should == 'loaded from repository'
   end
 
   it 'has a remote config but gets its config from the override file provided' do
     create_remote_config('loaded from remote repository')
     tempfile = create_override_file('loaded as override to override remote config')
-    configuration = invoke_find tempfile.path, FIG_REMOTE_URL
+    configuration = invoke_find tempfile.path, FIG_CONSUME_URL
     configuration['foo'].should == 'loaded as override to override remote config'
   end
 
   it 'merges override file config over remote config' do
     create_remote_config('loaded from remote repository', 'should not be overwritten')
     tempfile = create_override_file('loaded as override to override remote config')
-    configuration = invoke_find tempfile.path, FIG_REMOTE_URL
+    configuration = invoke_find tempfile.path, FIG_CONSUME_URL
     configuration['foo'].should == 'loaded as override to override remote config'
     configuration['bar'].should == 'should not be overwritten'
   end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -11,9 +11,9 @@ describe 'Parser' do
   def new_configuration
     application_configuration = Fig::ApplicationConfiguration.new
 
-    application_configuration.base_whitelisted_url = 'http://example/'
-    application_configuration.remote_consume_url = 'http://example/'
-    application_configuration.remote_publish_url = 'http://example/'
+    application_configuration.base_whitelisted_url = 'http://example.com/consume/'
+    application_configuration.remote_consume_url = 'http://example.com/consume/'
+    application_configuration.remote_publish_url = 'http://example.com/publish/'
 
     return application_configuration
   end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -11,9 +11,9 @@ describe 'Parser' do
   def new_configuration
     application_configuration = Fig::ApplicationConfiguration.new
 
-    application_configuration.base_whitelisted_url = 'http://example.com/consume/'
-    application_configuration.remote_consume_url = 'http://example.com/consume/'
-    application_configuration.remote_publish_url = 'http://example.com/publish/'
+    application_configuration.base_whitelisted_url = 'http://example/'
+    application_configuration.remote_consume_url = 'http://example/'
+    application_configuration.remote_publish_url = 'http://example/publish/'
 
     return application_configuration
   end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -12,7 +12,8 @@ describe 'Parser' do
     application_configuration = Fig::ApplicationConfiguration.new
 
     application_configuration.base_whitelisted_url = 'http://example/'
-    application_configuration.remote_repository_url = 'http://example/'
+    application_configuration.remote_consume_url = 'http://example/'
+    application_configuration.remote_publish_url = 'http://example/'
 
     return application_configuration
   end

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -15,7 +15,8 @@ require 'fig/statement/path'
 def create_local_repository()
   application_config = Fig::ApplicationConfiguration.new()
   application_config.base_whitelisted_url = FIG_REMOTE_URL
-  application_config.remote_repository_url = FIG_REMOTE_URL
+  application_config.remote_consume_url = FIG_REMOTE_URL
+  application_config.remote_publish_url = FIG_REMOTE_URL
 
   parser = Fig::Parser.new(application_config, false)
 

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -26,6 +26,7 @@ def create_local_repository()
     Fig::OperatingSystem.new(nil),
     FIG_HOME,
     FIG_CONSUME_URL,
+    FIG_PUBLISH_URL,
     parser,
     [],   # publish listeners
   )

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -14,9 +14,9 @@ require 'fig/statement/path'
 
 def create_local_repository()
   application_config = Fig::ApplicationConfiguration.new()
-  application_config.base_whitelisted_url = FIG_REMOTE_URL
-  application_config.remote_consume_url = FIG_REMOTE_URL
-  application_config.remote_publish_url = FIG_REMOTE_URL
+  application_config.base_whitelisted_url = FIG_CONSUME_URL
+  application_config.remote_consume_url = FIG_CONSUME_URL
+  application_config.remote_publish_url = FIG_PUBLISH_URL
 
   parser = Fig::Parser.new(application_config, false)
 
@@ -25,7 +25,7 @@ def create_local_repository()
     Fig::Command::Options.new,
     Fig::OperatingSystem.new(nil),
     FIG_HOME,
-    FIG_REMOTE_URL,
+    FIG_CONSUME_URL,
     parser,
     [],   # publish listeners
   )

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -268,7 +268,7 @@ def clean_up_test_environment()
   return
 end
 
-def cleanup_home_and_remote()
+def cleanup_home_and_remote(unified: true)
   FileUtils.rm_rf(FIG_HOME)
   FileUtils.rm_rf(FIG_REMOTE_DIR)
   
@@ -277,11 +277,17 @@ def cleanup_home_and_remote()
   FileUtils.rm_rf(FIG_PUBLISH_DIR)
   
   # Create base directories for split URLs
-  FileUtils.mkdir_p(FIG_CONSUME_DIR)
-  FileUtils.mkdir_p(File.join(FIG_CONSUME_DIR, Fig::Repository::METADATA_SUBDIRECTORY))
   FileUtils.mkdir_p(FIG_PUBLISH_DIR)
   FileUtils.mkdir_p(File.join(FIG_PUBLISH_DIR, Fig::Repository::METADATA_SUBDIRECTORY))
 
+  if unified
+    # use symlink to simulate an aggregated artifactory repo 
+    FileUtils.ln_sr(FIG_PUBLISH_DIR, FIG_CONSUME_DIR)
+  else
+    FileUtils.mkdir_p(FIG_CONSUME_DIR)
+    FileUtils.mkdir_p(File.join(FIG_CONSUME_DIR, Fig::Repository::METADATA_SUBDIRECTORY))
+  end
+  
   return
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,12 @@ CURRENT_DIRECTORY = FIG_SPEC_BASE_DIRECTORY + '/current-directory'
 USER_HOME         = FIG_SPEC_BASE_DIRECTORY + '/user-home'
 FIG_HOME          = FIG_SPEC_BASE_DIRECTORY + '/fig-home'
 FIG_REMOTE_DIR    = FIG_SPEC_BASE_DIRECTORY + '/remote'
+# For backward compatibility with existing tests
 FIG_REMOTE_URL    = %Q<file://#{FIG_REMOTE_DIR}>
+
+# For split URL behavior
+FIG_CONSUME_URL   = %Q<file://#{FIG_REMOTE_DIR}>
+FIG_PUBLISH_URL   = %Q<file://#{FIG_REMOTE_DIR}>
 
 FIG_DIRECTORY     ||= File.expand_path(File.dirname(__FILE__)) + '/../bin'
 FIG_COMMAND_CLASS ||= Fig::Command
@@ -56,7 +61,12 @@ BASE_FIG_COMMAND_LINE ||= [
 
 ENV['HOME']           = USER_HOME
 ENV['FIG_HOME']       = FIG_HOME
-ENV['FIG_REMOTE_URL'] = FIG_REMOTE_URL
+# Set up new environment variables for tests
+ENV['FIG_CONSUME_URL'] = FIG_CONSUME_URL
+ENV['FIG_PUBLISH_URL'] = FIG_PUBLISH_URL
+
+# For older tests that haven't been updated
+# ENV['FIG_REMOTE_URL'] = FIG_REMOTE_URL # Commented out to avoid errors
 ENV['FIG_COVERAGE_ROOT_DIRECTORY'] =
   File.expand_path(File.dirname(__FILE__) + '/..')
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,13 +31,13 @@ CURRENT_DIRECTORY = FIG_SPEC_BASE_DIRECTORY + '/current-directory'
 
 USER_HOME         = FIG_SPEC_BASE_DIRECTORY + '/user-home'
 FIG_HOME          = FIG_SPEC_BASE_DIRECTORY + '/fig-home'
-FIG_REMOTE_DIR    = FIG_SPEC_BASE_DIRECTORY + '/remote'
+#FIG_REMOTE_DIR    = FIG_SPEC_BASE_DIRECTORY + '/remote'
 # FIG_REMOTE_DIR     ||= File.join(FIG_SPEC_BASE_DIRECTORY, 'repository')
-FIG_REMOTE_URL    = %Q<file://#{FIG_REMOTE_DIR}>
+#FIG_REMOTE_URL    = %Q<file://#{FIG_REMOTE_DIR}>
 
 # For split URL behavior - using distinct directories to catch incorrect URL usage
-FIG_CONSUME_DIR   ||= File.join(FIG_SPEC_BASE_DIRECTORY, 'consume-repository')
-FIG_PUBLISH_DIR   ||= File.join(FIG_SPEC_BASE_DIRECTORY, 'publish-repository')
+FIG_CONSUME_DIR   = File.join(FIG_SPEC_BASE_DIRECTORY, 'remote')
+FIG_PUBLISH_DIR   = File.join(FIG_SPEC_BASE_DIRECTORY, 'publish')
 FIG_CONSUME_URL   = %Q<file://#{FIG_CONSUME_DIR}>
 FIG_PUBLISH_URL   = %Q<file://#{FIG_PUBLISH_DIR}>
 
@@ -244,16 +244,17 @@ def set_up_test_environment()
   FileUtils.mkdir_p CURRENT_DIRECTORY
   FileUtils.mkdir_p USER_HOME
   FileUtils.mkdir_p FIG_HOME
-  FileUtils.mkdir_p FIG_REMOTE_DIR
+  FileUtils.mkdir_p FIG_PUBLISH_DIR
+  FileUtils.ln_s FIG_PUBLISH_DIR, FIG_CONSUME_DIR
 
   FileUtils.touch FIG_FILE_GUARANTEED_TO_EXIST
 
   metadata_directory =
-    File.join FIG_REMOTE_DIR, Fig::Repository::METADATA_SUBDIRECTORY
+    File.join FIG_PUBLISH_DIR, Fig::Repository::METADATA_SUBDIRECTORY
   FileUtils.mkdir_p metadata_directory
 
   File.open(
-    File.join(FIG_REMOTE_DIR, Fig::FigRC::REPOSITORY_CONFIGURATION), 'w'
+    File.join(FIG_PUBLISH_DIR, Fig::FigRC::REPOSITORY_CONFIGURATION), 'w'
   ) do
     |handle|
     handle.puts '{}' # Empty Javascript/JSON object
@@ -270,7 +271,7 @@ end
 
 def cleanup_home_and_remote(unified: true)
   FileUtils.rm_rf(FIG_HOME)
-  FileUtils.rm_rf(FIG_REMOTE_DIR)
+  #FileUtils.rm_rf(FIG_REMOTE_DIR)
   
   # Clean up split URL directories
   FileUtils.rm_rf(FIG_CONSUME_DIR)
@@ -303,11 +304,11 @@ end
 
 def set_remote_repository_format_to_future_version()
   # Set future version in legacy remote dir
-  version_file = File.join(FIG_REMOTE_DIR, Fig::Repository::VERSION_FILE_NAME)
-  FileUtils.mkdir_p(FIG_REMOTE_DIR)
-  File.open(version_file, 'w') {
-    |handle| handle.write(Fig::Repository::REMOTE_VERSION_SUPPORTED + 1)
-  }
+  #version_file = File.join(FIG_REMOTE_DIR, Fig::Repository::VERSION_FILE_NAME)
+  #FileUtils.mkdir_p(FIG_REMOTE_DIR)
+  #File.open(version_file, 'w') {
+  #  |handle| handle.write(Fig::Repository::REMOTE_VERSION_SUPPORTED + 1)
+  #}
   
   # Set future version in consume dir
   version_file = File.join(FIG_CONSUME_DIR, Fig::Repository::VERSION_FILE_NAME)

--- a/spec/split_repo_url_spec.rb
+++ b/spec/split_repo_url_spec.rb
@@ -25,15 +25,14 @@ describe "Split repository URL behavior" do
       FileUtils.rm_rf(publish_dir)
 
       # Create the "repositories" based on whether we want unified or not
-      FileUtils.mkdir_p(consume_dir)
-      # Initialize metadata in both repos
-      FileUtils.mkdir_p(File.join(consume_dir, Fig::Repository::METADATA_SUBDIRECTORY))
+      FileUtils.mkdir_p(publish_dir)
+      FileUtils.mkdir_p(File.join(publish_dir, Fig::Repository::METADATA_SUBDIRECTORY))
 
       if unified
-        FileUtils.ln_s(consume_dir, publish_dir)
+        FileUtils.ln_sr(publish_dir, consume_dir)
       else
-        FileUtils.mkdir_p(publish_dir)
-        FileUtils.mkdir_p(File.join(publish_dir, Fig::Repository::METADATA_SUBDIRECTORY))
+        FileUtils.mkdir_p(consume_dir)
+        FileUtils.mkdir_p(File.join(consume_dir, Fig::Repository::METADATA_SUBDIRECTORY))
       end
 
       return consume_dir, publish_dir
@@ -80,7 +79,7 @@ describe "Split repository URL behavior" do
       ENV['FIG_PUBLISH_URL'] = publish_url
 
       consume_url.should_not == publish_url
-      FileTest.symlink?(publish_dir).should be true
+      FileTest.symlink?(consume_dir).should be true
       FileTest.identical?(publish_dir, consume_dir)
 
       # Create a simple package

--- a/spec/split_repo_url_spec.rb
+++ b/spec/split_repo_url_spec.rb
@@ -1,0 +1,191 @@
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+
+require 'fileutils'
+require 'tmpdir'
+
+require 'fig/command/package_loader'
+require 'fig/operating_system'
+require 'fig/repository'
+
+describe "Split repository URL behavior" do
+  context 'starting with a clean home and remote repository' do
+    before(:each) do
+      clean_up_test_environment
+      set_up_test_environment
+      cleanup_home_and_remote
+    end
+
+    def create_test_repos(unified: false)
+      # Name separate consume and publish directories
+      consume_dir = File.join(FIG_SPEC_BASE_DIRECTORY, 'consume-repo')
+      publish_dir = File.join(FIG_SPEC_BASE_DIRECTORY, 'publish-repo')
+
+      # Clean up any existing directories
+      FileUtils.rm_rf(consume_dir)
+      FileUtils.rm_rf(publish_dir)
+
+      # Create the "repositories" based on whether we want unified or not
+      FileUtils.mkdir_p(consume_dir)
+      # Initialize metadata in both repos
+      FileUtils.mkdir_p(File.join(consume_dir, Fig::Repository::METADATA_SUBDIRECTORY))
+
+      if unified
+        FileUtils.ln_s(consume_dir, publish_dir)
+      else
+        FileUtils.mkdir_p(publish_dir)
+        FileUtils.mkdir_p(File.join(publish_dir, Fig::Repository::METADATA_SUBDIRECTORY))
+      end
+
+      return consume_dir, publish_dir
+    end
+
+    it "(distinct repos) publishes to publish URL and consumes from consume URL" do
+      # Create separate repos
+      consume_dir, publish_dir = create_test_repos
+      consume_url = "file://#{consume_dir}"
+      publish_url = "file://#{publish_dir}"
+
+      # Set up environment for this test
+      ENV['FIG_CONSUME_URL'] = consume_url
+      ENV['FIG_PUBLISH_URL'] = publish_url
+
+      # Create a simple package
+      input = <<-END
+        config default
+          set FOO=BAR
+        end
+      END
+
+      # Create a package with publish-only
+      out, err, exit_code = 
+        fig(%w<--publish simple/1.2.3>, input, :no_raise_on_error => true)
+      exit_code.should == 0
+
+      # Check that package exists in publish repo but not in consume repo
+      publish_path = File.join(publish_dir, 'simple', '1.2.3', Fig::Repository::PACKAGE_FILE_IN_REPO)
+      consume_path = File.join(consume_dir, 'simple', '1.2.3', Fig::Repository::PACKAGE_FILE_IN_REPO)
+
+      File.exist?(publish_path).should be true
+      File.exist?(consume_path).should be false
+    end
+
+    it "(unified repos) publishes to publish URL and consumes from consume URL" do
+      # Create separate repos
+      consume_dir, publish_dir = create_test_repos(unified: true)
+      consume_url = "file://#{consume_dir}"
+      publish_url = "file://#{publish_dir}"
+
+      # Set up environment for this test
+      ENV['FIG_CONSUME_URL'] = consume_url
+      ENV['FIG_PUBLISH_URL'] = publish_url
+
+      consume_url.should_not == publish_url
+      FileTest.symlink?(publish_dir).should be true
+      FileTest.identical?(publish_dir, consume_dir)
+
+      # Create a simple package
+      input = <<-END
+        config default
+          set FOO=BAR
+        end
+      END
+
+      # Create a package with publish-only
+      out, err, exit_code = 
+        fig(%w<--publish simple/1.2.3>, input, :no_raise_on_error => true)
+      exit_code.should == 0
+
+      # Check that package exists in publish repo AND in consume repo
+      publish_path = File.join(publish_dir, 'simple', '1.2.3', Fig::Repository::PACKAGE_FILE_IN_REPO)
+      consume_path = File.join(consume_dir, 'simple', '1.2.3', Fig::Repository::PACKAGE_FILE_IN_REPO)
+
+      File.exist?(publish_path).should be true
+      File.exist?(consume_path).should be true
+    end
+    it "warns when FIG_REMOTE_URL is set alongside the new URLs" do
+      # Set up conflicting environment
+      ENV['FIG_REMOTE_URL'] = "file:///some/path"
+      ENV['FIG_CONSUME_URL'] = "file:///consume/path"
+      ENV['FIG_PUBLISH_URL'] = "file:///publish/path"
+
+      # We need to mock the $stderr output since that's where the warning goes
+      # Capture original stderr and redirect to a StringIO
+      original_stderr = $stderr
+      $stderr = StringIO.new
+
+      # Create a minimal default.fig file for the test to work
+      File.open('default.fig', 'w') { |f| f.puts "config default\nend" }
+
+      # Use Fig::FigRC directly to trigger the warning
+      Fig::FigRC.find(nil, ENV['FIG_REMOTE_URL'], 
+                    Fig::OperatingSystem.new(false), 
+                    FIG_HOME)
+
+      # Get the captured output and restore stderr
+      err_output = $stderr.string
+      $stderr = original_stderr
+
+      # Check that the warning was emitted
+      err_output.should =~ /WARNING: FIG_REMOTE_URL is set but will be ignored/
+
+      # Clean up
+      File.unlink('default.fig') if File.exist?('default.fig')
+    end
+
+    it "fails when FIG_REMOTE_URL is set but new URLs are missing" do
+      # Set up invalid environment
+      ENV['FIG_REMOTE_URL'] = "file:///some/path"
+      ENV.delete('FIG_CONSUME_URL')
+      ENV.delete('FIG_PUBLISH_URL')
+
+      # Create a minimal default.fig file for the test to work
+      File.open('default.fig', 'w') { |f| f.puts "config default\nend" }
+
+      # Try to use fig with remote operation, should get error
+      out, err, exit_code = fig(%w<--update>, :no_raise_on_error => true)
+
+      # Should fail with clear error message
+      exit_code.should_not == 0
+      err.should =~ /FIG_REMOTE_URL is set but FIG_CONSUME_URL and\/or FIG_PUBLISH_URL are missing/
+
+      # Clean up
+      File.unlink('default.fig') if File.exist?('default.fig')
+    end
+
+    it "fails with helpful message when required URL is missing" do
+      # Make sure we have no URLs set
+      ENV.delete('FIG_REMOTE_URL')
+      ENV.delete('FIG_CONSUME_URL')
+      ENV.delete('FIG_PUBLISH_URL')
+
+      # Publishing without publish URL
+      input = <<-END
+        config default
+          set FOO=BAR
+        end
+      END
+
+      out, err, exit_code = fig(%w<--publish simple/1.2.3>, input, :no_raise_on_error => true)
+      exit_code.should_not == 0
+      err.should =~ /Please define the FIG_PUBLISH_URL environment variable/
+
+      # Consuming without consume URL
+      out, err, exit_code = fig(%w<--update>, :no_raise_on_error => true)
+      exit_code.should_not == 0
+      err.should =~ /Please define the FIG_CONSUME_URL environment variable/
+    end
+  end
+
+  after(:all) do
+    # Clean up and restore environment
+    consume_dir = File.join(FIG_SPEC_BASE_DIRECTORY, 'consume-repo')
+    publish_dir = File.join(FIG_SPEC_BASE_DIRECTORY, 'publish-repo')
+    FileUtils.rm_rf(consume_dir) if Dir.exist?(consume_dir)
+    FileUtils.rm_rf(publish_dir) if Dir.exist?(publish_dir)
+
+    # Restore environment variables to default test values
+    ENV['FIG_CONSUME_URL'] = FIG_CONSUME_URL
+    ENV['FIG_PUBLISH_URL'] = FIG_PUBLISH_URL
+    ENV.delete('FIG_REMOTE_URL')
+  end
+end


### PR DESCRIPTION
This is a pre-requisite for supporting an artifactory split repo (next on list).

Current/legacy fig uses `FIG_REMOTE_URL` to specify the consume and the publish URL.  This implementation abandons the current/legacy fig `FIG_REMOTE_URL` that in favor of `FIG_CONSUME_URL` and `FIG_PUBLISH_URL` since we want to strongarm people into using the spit repos, and requires specifying BOTH values.

I'm open to the possibility that this position is too strong, especially if most fig users are simply consumers.  If that's the case, then maybe I should consider only requiring `FIG_CONSUME_URL` and making `FIG_PUBLISH_URL` only required when publishing?  For that matter, then, I wonder if I should then just change the meaning of `FIG_REMOTE_URL` to be only for consuming?

Doing that would change the configuration rules from what's currently implemented in this branch to:
- _consumer_ role -- `FIG_REMOTE_URL` (or `FIG_CONSUME_URL`?) required, `FIG_PUBLISH_URL` not needed and unused
- _publisher_ role -- `FIG_PUBLISH_URL` required; `FIG_<whichever>_URL` (where <wherever> could be `REMOTE` or `CONSUME`) not needed and unused

I do feel strongly that there only be ONE variable chosen for the consumer side role, not an either/or.  There's some advantage to switching `FIG_REMOTE_URL` to a consume-only interpretation in that consume-only workflows would not have to change their config other than the value for the URL, but there's disadvantage in that it changes semantics which may be confusing.  Changing the variable names makes it abundantly clear what's being used how, plus users could continue to use `FIG_REMOTE_URL` with the existing values in the same .figrc and share that .figrc with legacy fig.