### PR TITLE
Simplify steps required to publish a new release.

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,53 @@
+name: Auto-tag on version change
+
+# Trigger only when lib/fig/version.rb changes on master
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'lib/fig/version.rb'
+
+permissions:
+  contents: write
+
+jobs:
+  # Auto-tag when version.rb changes on master
+  # 
+  # HOW TO TRIGGER A RELEASE:
+  # 1. Edit lib/fig/version.rb and change the VERSION string (e.g., '2.0.0-alpha.6' → '2.0.0-alpha.7')
+  # 2. Commit and push to master branch
+  # 3. This workflow will automatically create a git tag (e.g., v2.0.0-alpha.7)
+  # 4. The existing 'publish' job in build-and-test.yml will trigger on the tag and publish the gem to RubyGems
+  #
+  # FUTURE IMPROVEMENT:
+  # This manual process could be automated using conventional commits and release-please.
+  # See: https://github.com/googleapis/release-please#how-release-please-works
+  # With conventional commits, you'd use commit messages like:
+  #   - "feat: add new feature" (minor version bump)
+  #   - "fix: resolve bug" (patch version bump)  
+  #   - "feat!: breaking change" (major version bump)
+  # And release-please would automatically create PRs with version bumps.
+  auto-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+          
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3.7'
+          
+      - name: Extract version
+        id: version
+        run: |
+          VERSION=$(ruby -r ./lib/fig/version -e 'puts Fig::VERSION')
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "Version found: $VERSION"
+          
+      - name: Create tag
+        uses: rickstaa/action-create-tag@v1
+        with:
+          tag: v${{ env.VERSION }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          message: "Release v${{ env.VERSION }}"


### PR DESCRIPTION
Releasing needs to be simple, because people aren't going to be firing off new releases of fig on the daily.  I personally found myself forgetting steps and having to rebase/amend, move tags, etc.

This change tightly couples the tag to the version file change, automating tag creation from the version file committed to master.  The decision for when to release, which semver component to bump and what value to use, etc., all remains very manual.  A better future choice is conventional commits and release-please.