### PR TITLE
Fix failure to create GH release due to missing tag.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -225,6 +225,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+          fetch-tags: true
 
       - name: Download gem artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
The tag created by job 'auto-tag' doesn't normally get pulled as part of the checkout.  This ensures that tags get pulled as part of the publish job's checkout and, thus, the tag is available to the action-gh-release step.