### PR TITLE
Fix artifactory path_up_to_date? issues

### DIFF
--- a/lib/fig/protocol/artifactory.rb
+++ b/lib/fig/protocol/artifactory.rb
@@ -177,7 +177,9 @@ class Fig::Protocol::Artifactory
       response = client.get(storage_url)
       
       # compare sizes first
-      if response['size'] != ::File.size(path)
+      remote_size = response['size'].to_i
+      if remote_size != ::File.size(path)
+        # TODO VERBOSE
         return false
       end
       
@@ -188,7 +190,8 @@ class Fig::Protocol::Artifactory
       if remote_mtime <= local_mtime
         return true
       end
-      
+
+      # TODO VERBOSE
       return false
     rescue => error
       Fig::Logging.debug "Error checking if #{path} is up to date: #{error.message}"

--- a/lib/fig/version.rb
+++ b/lib/fig/version.rb
@@ -1,5 +1,5 @@
 # coding: utf-8
 
 module Fig
-  VERSION = '2.0.0-alpha.10'.freeze
+  VERSION = '2.0.0-alpha.11'.freeze
 end


### PR DESCRIPTION
This fixes a bug where path_up_to_date? would always evaluate to `false` due to a type-incorrect comparison related to size values.