### PR TITLE
Add --verbose and unused override warnings.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fig (2.0.0.pre.alpha.5)
+    fig (2.0.0.pre.alpha.11)
       artifactory (~> 3.0.17)
       base64 (~> 0.2.0)
       bcrypt_pbkdf (~> 1.1.0)

--- a/lib/fig/command.rb
+++ b/lib/fig/command.rb
@@ -194,6 +194,15 @@ class Fig::Command
     return ! suppressed_warnings.include?('unused retrieve')
   end
 
+  def check_for_unused_overrides?()
+    return false if @options.suppress_warning_unused_override?
+
+    suppressed_warnings = @application_configuration['suppress warnings']
+    return true if not suppressed_warnings
+
+    return ! suppressed_warnings.include?('unused override')
+  end
+
   def configure()
     set_up_update_lock()
 
@@ -346,6 +355,14 @@ class Fig::Command
       Fig::AtExit.add {
         if ! @suppress_further_error_messages
           @environment.check_for_unused_retrieves
+        end
+      }
+    end
+
+    if check_for_unused_overrides?
+      Fig::AtExit.add {
+        if ! @suppress_further_error_messages
+          @environment.check_for_unused_overrides
         end
       }
     end

--- a/lib/fig/command.rb
+++ b/lib/fig/command.rb
@@ -22,6 +22,7 @@ require 'fig/runtime_environment'
 require 'fig/statement/configuration'
 require 'fig/update_lock'
 require 'fig/user_input_error'
+require 'fig/verbose_logging'
 require 'fig/working_directory_maintainer'
 
 module Fig; end
@@ -46,6 +47,11 @@ class Fig::Command
     Fig::Logging.initialize_pre_configuration(
       @options.log_to_stdout(), @options.log_level(),
     )
+    
+    # Enable verbose logging if requested
+    if @options.verbose
+      Fig::VerboseLogging.enable_verbose!
+    end
 
     actions = @options.actions()
     if actions.empty?

--- a/lib/fig/command/options.rb
+++ b/lib/fig/command/options.rb
@@ -178,6 +178,10 @@ class Fig::Command::Options
     return @suppress_warning_unused_retrieve
   end
 
+  def suppress_warning_unused_override?()
+    return @suppress_warning_unused_override
+  end
+
   private
 
   EXTRA_OPTIONS_DESCRIPTION = <<-'END_DESCRIPTION'
@@ -780,6 +784,13 @@ Running commands:
       %q<don't complain about a retrieve statement that isn't used>
     ) do
       @suppress_warning_unused_retrieve = true
+    end
+
+    @parser.on(
+      '--suppress-warning-unused-override',
+      %q<don't complain about an override statement that isn't used>
+    ) do
+      @suppress_warning_unused_override = true
     end
 
     return

--- a/lib/fig/command/options.rb
+++ b/lib/fig/command/options.rb
@@ -79,6 +79,7 @@ class Fig::Command::Options
   attr_reader   :suppress_retrieves
   attr_reader   :update_lock_response
   attr_reader   :variable_to_get
+  attr_reader   :verbose
   attr_accessor :version_message
   attr_accessor :version_plain
 
@@ -739,6 +740,13 @@ Running commands:
       "  (#{level_list})"
     ) do |log_level|
       @log_level = log_level
+    end
+
+    @parser.on(
+      '--verbose',
+      'enable verbose output with timing information'
+    ) do
+      @verbose = true
     end
 
     @update_lock_response = nil # Nil means wait, but warn.

--- a/lib/fig/command/options/parser.rb
+++ b/lib/fig/command/options/parser.rb
@@ -94,7 +94,7 @@ Standard options (represented as "[...]" above):
 
       [-l | --login]
 
-      [--log-level LEVEL] [--log-config PATH | --log-to-stdout]
+      [--log-level LEVEL] [--log-config PATH | --log-to-stdout] [--verbose]
       [--figrc PATH]      [--no-figrc] [--no-remote-figrc]
 
       [--suppress-vcs-comments-in-published-packages]

--- a/lib/fig/operating_system.rb
+++ b/lib/fig/operating_system.rb
@@ -381,13 +381,14 @@ class Fig::OperatingSystem
     return
   end
 
-  private
-
   def log_repository_operation(operation, url_or_path, details = nil)
     message = "repository #{operation}: #{url_or_path}"
     message += " (#{details})" if details
     Fig::VerboseLogging.verbose message
   end
+
+  private
+
   
   def log_asset_operation(operation, asset_path, size_bytes = nil)
     message = "asset #{operation}: #{asset_path}"

--- a/lib/fig/operating_system.rb
+++ b/lib/fig/operating_system.rb
@@ -105,7 +105,7 @@ class Fig::OperatingSystem
         protocol, uri = decode_protocol url
 
         result = protocol.download_list uri
-        Fig::VerboseLogging.log_repository_operation("listed", url, "#{result.size} entries")
+        log_repository_operation("listed", url, "#{result.size} entries")
         result
       rescue SocketError => error
         Fig::Logging.debug error.message
@@ -137,7 +137,7 @@ class Fig::OperatingSystem
       result = protocol.download uri, path, prompt_for_login
       if File.exist?(path)
         size = File.size(path)
-        Fig::VerboseLogging.log_asset_operation("downloaded", path, size)
+        log_asset_operation("downloaded", path, size)
       end
       result
     end
@@ -239,7 +239,7 @@ class Fig::OperatingSystem
     Fig::VerboseLogging.time_operation("extracting archive #{File.basename(archive_path)}") do
       FileUtils.mkdir_p directory
       archive_size = File.size(archive_path) if File.exist?(archive_path)
-      Fig::VerboseLogging.log_asset_operation("extracting", archive_path, archive_size)
+      log_asset_operation("extracting", archive_path, archive_size)
       
       Dir.chdir(directory) do
         if ! File.exist? archive_path
@@ -379,5 +379,33 @@ class Fig::OperatingSystem
     )
 
     return
+  end
+
+  private
+
+  def log_repository_operation(operation, url_or_path, details = nil)
+    message = "repository #{operation}: #{url_or_path}"
+    message += " (#{details})" if details
+    Fig::VerboseLogging.verbose message
+  end
+  
+  def log_asset_operation(operation, asset_path, size_bytes = nil)
+    message = "asset #{operation}: #{asset_path}"
+    message += " (#{format_bytes(size_bytes)})" if size_bytes
+    Fig::VerboseLogging.verbose message
+  end
+
+  def format_bytes(bytes)
+    return nil unless bytes
+    
+    if bytes < 1024
+      "#{bytes}B"
+    elsif bytes < 1024 * 1024
+      "#{(bytes / 1024.0).round(1)}KB"
+    elsif bytes < 1024 * 1024 * 1024
+      "#{(bytes / (1024.0 * 1024)).round(1)}MB"
+    else
+      "#{(bytes / (1024.0 * 1024 * 1024)).round(1)}GB"
+    end
   end
 end

--- a/lib/fig/operating_system.rb
+++ b/lib/fig/operating_system.rb
@@ -145,6 +145,7 @@ class Fig::OperatingSystem
 
   # Returns the basename and full path to the download.
   def download_resource(url, download_directory)
+    log_asset_operation("downloading", url)
     FileUtils.mkdir_p(download_directory)
 
     basename = CGI.unescape Fig::URL.parse(url).path.split('/').last
@@ -156,6 +157,7 @@ class Fig::OperatingSystem
   end
 
   def download_and_unpack_archive(url, download_directory, unpack_directory)
+    log_asset_operation("downloading", url)
     basename, path = download_resource(url, download_directory)
 
     case path
@@ -389,7 +391,6 @@ class Fig::OperatingSystem
 
   private
 
-  
   def log_asset_operation(operation, asset_path, size_bytes = nil)
     message = "asset #{operation}: #{asset_path}"
     message += " (#{format_bytes(size_bytes)})" if size_bytes

--- a/lib/fig/repository.rb
+++ b/lib/fig/repository.rb
@@ -83,7 +83,7 @@ class Fig::Repository
     Fig::VerboseLogging.time_operation("listing remote packages from #{remote_download_url()}") do
       paths = @operating_system.download_list(remote_download_url())
       filtered_paths = paths.reject { |path| path =~ %r< ^ #{METADATA_SUBDIRECTORY} / >xs }
-      @operating_system.log_repository_operation("found", remote_download_url(), "#{filtered_paths.size} packages")
+      Fig::VerboseLogging.verbose "found #{filtered_paths.size} packages at #{remote_download_url()}"
       filtered_paths
     end
   end
@@ -440,7 +440,6 @@ class Fig::Repository
       end
       
       Fig::VerboseLogging.time_operation("downloading and unpacking archive #{File.basename(archive_location)}") do
-        Fig::VerboseLogging.log_asset_operation("downloading", archive_location)
         @operating_system.download_and_unpack_archive(
           archive_location, temporary_package, temporary_runtime
         )
@@ -457,7 +456,6 @@ class Fig::Repository
       end
 
       Fig::VerboseLogging.time_operation("downloading resource #{File.basename(resource_location)}") do
-        Fig::VerboseLogging.log_asset_operation("downloading", resource_location)
         basename, path =
           @operating_system.download_resource(
             resource_location, temporary_package

--- a/lib/fig/repository.rb
+++ b/lib/fig/repository.rb
@@ -15,6 +15,7 @@ require 'fig/parser'
 require 'fig/repository_error'
 require 'fig/repository_package_publisher'
 require 'fig/url'
+require 'fig/verbose_logging'
 
 module Fig; end
 
@@ -79,9 +80,12 @@ class Fig::Repository
   def list_remote_packages
     check_remote_repository_format()
 
-    paths = @operating_system.download_list(remote_download_url())
-
-    return paths.reject { |path| path =~ %r< ^ #{METADATA_SUBDIRECTORY} / >xs }
+    Fig::VerboseLogging.time_operation("listing remote packages from #{remote_download_url()}") do
+      paths = @operating_system.download_list(remote_download_url())
+      filtered_paths = paths.reject { |path| path =~ %r< ^ #{METADATA_SUBDIRECTORY} / >xs }
+      Fig::VerboseLogging.log_repository_operation("found", remote_download_url(), "#{filtered_paths.size} packages")
+      filtered_paths
+    end
   end
 
   def get_package(
@@ -296,25 +300,27 @@ class Fig::Repository
   end
 
   def update_package(descriptor)
-    temp_dir = package_download_temp_dir(descriptor)
-    begin
-      install_package(descriptor, temp_dir)
-    rescue Fig::FileNotFoundError => error
-      if @updating_package_definition
-        Fig::Logging.fatal \
-          "Package #{descriptor.to_string} not found in remote repository. (Was looking for #{error.path}.)"
-      else
-        Fig::Logging.fatal \
-          "Part of package #{descriptor.to_string} was not downloadable. (Was attempting to get #{error.path}.)"
+    Fig::VerboseLogging.time_operation("downloading package #{descriptor.to_string}") do
+      temp_dir = package_download_temp_dir(descriptor)
+      begin
+        install_package(descriptor, temp_dir)
+      rescue Fig::FileNotFoundError => error
+        if @updating_package_definition
+          Fig::Logging.fatal \
+            "Package #{descriptor.to_string} not found in remote repository. (Was looking for #{error.path}.)"
+        else
+          Fig::Logging.fatal \
+            "Part of package #{descriptor.to_string} was not downloadable. (Was attempting to get #{error.path}.)"
+        end
+
+        raise Fig::RepositoryError.new
+      rescue StandardError => exception
+        Fig::Logging.fatal %Q<Install of #{descriptor.to_string} failed: #{exception}>
+
+        raise Fig::RepositoryError.new
+      ensure
+        FileUtils.rm_rf(temp_dir)
       end
-
-      raise Fig::RepositoryError.new
-    rescue StandardError => exception
-      Fig::Logging.fatal %Q<Install of #{descriptor.to_string} failed: #{exception}>
-
-      raise Fig::RepositoryError.new
-    ensure
-      FileUtils.rm_rf(temp_dir)
     end
 
     return
@@ -423,6 +429,7 @@ class Fig::Repository
 
   def download_assets(package, descriptor, temporary_package, temporary_runtime)
     remote_package_directory = remote_directory_for_package(descriptor)
+    
     package.archive_locations.each do
       |archive_location|
 
@@ -431,10 +438,15 @@ class Fig::Repository
           remote_package_directory, [archive_location]
         )
       end
-      @operating_system.download_and_unpack_archive(
-        archive_location, temporary_package, temporary_runtime
-      )
+      
+      Fig::VerboseLogging.time_operation("downloading and unpacking archive #{File.basename(archive_location)}") do
+        Fig::VerboseLogging.log_asset_operation("downloading", archive_location)
+        @operating_system.download_and_unpack_archive(
+          archive_location, temporary_package, temporary_runtime
+        )
+      end
     end
+    
     package.resource_locations.each do
       |resource_location|
 
@@ -444,12 +456,15 @@ class Fig::Repository
         )
       end
 
-      basename, path =
-        @operating_system.download_resource(
-          resource_location, temporary_package
-        )
+      Fig::VerboseLogging.time_operation("downloading resource #{File.basename(resource_location)}") do
+        Fig::VerboseLogging.log_asset_operation("downloading", resource_location)
+        basename, path =
+          @operating_system.download_resource(
+            resource_location, temporary_package
+          )
 
-      @operating_system.copy path, File.join(temporary_runtime, basename)
+        @operating_system.copy path, File.join(temporary_runtime, basename)
+      end
     end
 
     return

--- a/lib/fig/repository.rb
+++ b/lib/fig/repository.rb
@@ -83,7 +83,7 @@ class Fig::Repository
     Fig::VerboseLogging.time_operation("listing remote packages from #{remote_download_url()}") do
       paths = @operating_system.download_list(remote_download_url())
       filtered_paths = paths.reject { |path| path =~ %r< ^ #{METADATA_SUBDIRECTORY} / >xs }
-      Fig::VerboseLogging.log_repository_operation("found", remote_download_url(), "#{filtered_paths.size} packages")
+      @operating_system.log_repository_operation("found", remote_download_url(), "#{filtered_paths.size} packages")
       filtered_paths
     end
   end

--- a/lib/fig/runtime_environment.rb
+++ b/lib/fig/runtime_environment.rb
@@ -42,6 +42,7 @@ class Fig::RuntimeEnvironment
     @retrieves                    = {}
     @named_packages               = {}
     @working_directory_maintainer = working_directory_maintainer
+    @all_override_statements      = []
   end
 
   # Returns the value of an environment variable
@@ -175,6 +176,7 @@ class Fig::RuntimeEnvironment
       include_file_config(package, statement, backtrace, current_package_depth)
     when Fig::Statement::Override
       backtrace.add_override(statement)
+      @all_override_statements << statement
     end
 
     return
@@ -191,6 +193,15 @@ class Fig::RuntimeEnvironment
         )
         Fig::Logging.warn \
           %Q<The #{name} variable was never referenced or didn't need expansion, so "#{text.strip}"#{statement.position_string} was ignored.>
+      end
+    end
+  end
+
+  def check_for_unused_overrides()
+    @all_override_statements.each do |statement|
+      if statement.loaded_but_not_referenced?
+        Fig::Logging.warn \
+          %Q<Override "#{statement.package_name}/#{statement.version}"#{statement.position_string} was never used.>
       end
     end
   end

--- a/lib/fig/runtime_environment.rb
+++ b/lib/fig/runtime_environment.rb
@@ -228,7 +228,10 @@ class Fig::RuntimeEnvironment
     end
 
     apply_config(
-      package, resolved_descriptor.config, new_backtrace, next_package_depth
+      package,
+      resolved_descriptor.config || Fig::Package::DEFAULT_CONFIG,
+      new_backtrace,
+      next_package_depth
     )
 
     return

--- a/lib/fig/spec_utils.rb
+++ b/lib/fig/spec_utils.rb
@@ -18,6 +18,14 @@ require 'fig/external_program'
 require 'fig/figrc'
 require 'fig/logging'
 require 'fig/repository'
+require 'fig/verbose_logging'
+
+# Reset verbose logging state before each test to prevent test pollution
+RSpec.configure do |config|
+  config.before(:each) do
+    Fig::VerboseLogging.disable_verbose!
+  end
+end
 
 FIG_SPEC_BASE_DIRECTORY = Dir.mktmpdir 'fig-rspec-'
 at_exit { FileUtils.rm_rf FIG_SPEC_BASE_DIRECTORY }

--- a/lib/fig/statement/override.rb
+++ b/lib/fig/statement/override.rb
@@ -35,6 +35,26 @@ class Fig::Statement::Override < Fig::Statement
     @version = version
   end
 
+  def loaded_but_not_referenced?()
+    return added_to_environment? && ! referenced?
+  end
+
+  def added_to_environment?()
+    return @added_to_environment
+  end
+
+  def added_to_environment(yea_or_nay)
+    @added_to_environment = yea_or_nay
+  end
+
+  def referenced?()
+    return @referenced
+  end
+
+  def referenced(yea_or_nay)
+    @referenced = yea_or_nay
+  end
+
   def statement_type()
     return 'override'
   end

--- a/lib/fig/verbose_logging.rb
+++ b/lib/fig/verbose_logging.rb
@@ -12,6 +12,10 @@ module Fig::VerboseLogging
     @@verbose_enabled = true
   end
   
+  def self.disable_verbose!
+    @@verbose_enabled = false
+  end
+  
   def self.verbose_enabled?
     @@verbose_enabled
   end

--- a/lib/fig/verbose_logging.rb
+++ b/lib/fig/verbose_logging.rb
@@ -66,18 +66,4 @@ module Fig::VerboseLogging
       "#{minutes}m #{remaining_seconds.round(1)}s"
     end
   end
-  
-  def self.format_bytes(bytes)
-    return "unknown size" unless bytes
-    
-    if bytes < 1024
-      "#{bytes}B"
-    elsif bytes < 1024 * 1024
-      "#{(bytes / 1024.0).round(1)}KB"
-    elsif bytes < 1024 * 1024 * 1024
-      "#{(bytes / (1024.0 * 1024)).round(1)}MB"
-    else
-      "#{(bytes / (1024.0 * 1024 * 1024)).round(1)}GB"
-    end
-  end
 end

--- a/lib/fig/verbose_logging.rb
+++ b/lib/fig/verbose_logging.rb
@@ -4,7 +4,7 @@ require 'fig/logging'
 
 module Fig; end
 
-# Enhanced logging with timing for verbose operations
+# Core verbose logging infrastructure with timing support
 module Fig::VerboseLogging
   @@verbose_enabled = false
   
@@ -51,74 +51,6 @@ module Fig::VerboseLogging
       verbose "failed #{operation_name} after #{format_duration(duration)}: #{error.class.name}: #{error.message}"
       raise
     end
-  end
-  
-  def self.log_dependency_resolution(package_name, version, config, depth)
-    return unless should_log_verbose?
-    
-    # Skip logging for synthetic/unnamed packages 
-    return if package_name.nil? || package_name.empty?
-    
-    indent = "  " * depth
-    version_str = version || "<no version>"
-    config_str = config || "default"
-    verbose "#{indent}resolving dependency: #{package_name}/#{version_str}:#{config_str}"
-  end
-  
-  def self.log_package_include(package_descriptor, depth)
-    return unless should_log_verbose?
-    
-    # Skip logging for synthetic/unnamed packages at root level
-    if depth == 0 && package_descriptor.respond_to?(:name) && 
-       (package_descriptor.name.nil? || package_descriptor.name.empty?)
-      return
-    end
-    
-    indent = "  " * depth
-    if package_descriptor.respond_to?(:to_string)
-      descriptor_string = package_descriptor.to_string
-    elsif package_descriptor.respond_to?(:name) && package_descriptor.respond_to?(:version)
-      name = package_descriptor.name || "<unnamed>"
-      version = package_descriptor.version || "<no version>"
-      config = package_descriptor.config || "default"
-      descriptor_string = "#{name}/#{version}:#{config}"
-    else
-      descriptor_string = package_descriptor.to_s
-    end
-    verbose "#{indent}including package: #{descriptor_string}"
-  end
-  
-  def self.log_override_applied(package_name, original_version, override_version, depth)
-    return unless should_log_verbose?
-    
-    indent = "  " * depth
-    verbose "#{indent}override applied: #{package_name}/#{original_version} -> #{package_name}/#{override_version}"
-  end
-  
-  def self.log_config_processing(package_name, version, config_name)
-    return unless should_log_verbose?
-    
-    if package_name && !package_name.empty?
-      verbose "processing config #{config_name} for package #{package_name}/#{version || '<no version>'}"
-    else
-      verbose "processing config #{config_name} for command-line package"
-    end
-  end
-  
-  def self.log_repository_operation(operation, url_or_path, details = nil)
-    return unless should_log_verbose?
-    
-    message = "repository #{operation}: #{url_or_path}"
-    message += " (#{details})" if details
-    verbose message
-  end
-  
-  def self.log_asset_operation(operation, asset_path, size_bytes = nil)
-    return unless should_log_verbose?
-    
-    message = "asset #{operation}: #{asset_path}"
-    message += " (#{format_bytes(size_bytes)})" if size_bytes
-    verbose message
   end
   
   private

--- a/lib/fig/verbose_logging.rb
+++ b/lib/fig/verbose_logging.rb
@@ -1,0 +1,147 @@
+# coding: utf-8
+
+require 'fig/logging'
+
+module Fig; end
+
+# Enhanced logging with timing for verbose operations
+module Fig::VerboseLogging
+  @@verbose_enabled = false
+  
+  def self.enable_verbose!
+    @@verbose_enabled = true
+  end
+  
+  def self.verbose_enabled?
+    @@verbose_enabled
+  end
+  
+  def self.should_log_verbose?
+    @@verbose_enabled || Fig::Logging.debug?
+  end
+  
+  def self.verbose(message)
+    return unless should_log_verbose?
+    
+    if Fig::Logging.info?
+      Fig::Logging.info "[VERBOSE] #{message}"
+    else
+      # fallback to stderr if logging is completely disabled
+      $stderr.puts "[VERBOSE] #{message}" if @@verbose_enabled
+    end
+  end
+  
+  def self.time_operation(operation_name, &block)
+    return yield unless should_log_verbose?
+    
+    start_time = Time.now
+    verbose "starting #{operation_name}"
+    
+    begin
+      result = yield
+      duration = Time.now - start_time
+      verbose "completed #{operation_name} in #{format_duration(duration)}"
+      result
+    rescue => error
+      duration = Time.now - start_time
+      verbose "failed #{operation_name} after #{format_duration(duration)}: #{error.class.name}: #{error.message}"
+      raise
+    end
+  end
+  
+  def self.log_dependency_resolution(package_name, version, config, depth)
+    return unless should_log_verbose?
+    
+    # Skip logging for synthetic/unnamed packages 
+    return if package_name.nil? || package_name.empty?
+    
+    indent = "  " * depth
+    version_str = version || "<no version>"
+    config_str = config || "default"
+    verbose "#{indent}resolving dependency: #{package_name}/#{version_str}:#{config_str}"
+  end
+  
+  def self.log_package_include(package_descriptor, depth)
+    return unless should_log_verbose?
+    
+    # Skip logging for synthetic/unnamed packages at root level
+    if depth == 0 && package_descriptor.respond_to?(:name) && 
+       (package_descriptor.name.nil? || package_descriptor.name.empty?)
+      return
+    end
+    
+    indent = "  " * depth
+    if package_descriptor.respond_to?(:to_string)
+      descriptor_string = package_descriptor.to_string
+    elsif package_descriptor.respond_to?(:name) && package_descriptor.respond_to?(:version)
+      name = package_descriptor.name || "<unnamed>"
+      version = package_descriptor.version || "<no version>"
+      config = package_descriptor.config || "default"
+      descriptor_string = "#{name}/#{version}:#{config}"
+    else
+      descriptor_string = package_descriptor.to_s
+    end
+    verbose "#{indent}including package: #{descriptor_string}"
+  end
+  
+  def self.log_override_applied(package_name, original_version, override_version, depth)
+    return unless should_log_verbose?
+    
+    indent = "  " * depth
+    verbose "#{indent}override applied: #{package_name}/#{original_version} -> #{package_name}/#{override_version}"
+  end
+  
+  def self.log_config_processing(package_name, version, config_name)
+    return unless should_log_verbose?
+    
+    if package_name && !package_name.empty?
+      verbose "processing config #{config_name} for package #{package_name}/#{version || '<no version>'}"
+    else
+      verbose "processing config #{config_name} for command-line package"
+    end
+  end
+  
+  def self.log_repository_operation(operation, url_or_path, details = nil)
+    return unless should_log_verbose?
+    
+    message = "repository #{operation}: #{url_or_path}"
+    message += " (#{details})" if details
+    verbose message
+  end
+  
+  def self.log_asset_operation(operation, asset_path, size_bytes = nil)
+    return unless should_log_verbose?
+    
+    message = "asset #{operation}: #{asset_path}"
+    message += " (#{format_bytes(size_bytes)})" if size_bytes
+    verbose message
+  end
+  
+  private
+  
+  def self.format_duration(seconds)
+    if seconds < 1.0
+      "#{(seconds * 1000).round(1)}ms"
+    elsif seconds < 60.0
+      "#{seconds.round(2)}s"
+    else
+      minutes = (seconds / 60).floor
+      remaining_seconds = seconds - (minutes * 60)
+      "#{minutes}m #{remaining_seconds.round(1)}s"
+    end
+  end
+  
+  def self.format_bytes(bytes)
+    return "unknown size" unless bytes
+    
+    if bytes < 1024
+      "#{bytes}B"
+    elsif bytes < 1024 * 1024
+      "#{(bytes / 1024.0).round(1)}KB"
+    elsif bytes < 1024 * 1024 * 1024
+      "#{(bytes / (1024.0 * 1024)).round(1)}MB"
+    else
+      "#{(bytes / (1024.0 * 1024 * 1024)).round(1)}GB"
+    end
+  end
+end

--- a/lib/fig/verbose_logging.rb
+++ b/lib/fig/verbose_logging.rb
@@ -38,22 +38,20 @@ module Fig::VerboseLogging
   def self.time_operation(operation_name, &block)
     return yield unless should_log_verbose?
     
-    start_time = Time.now
+    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     verbose "starting #{operation_name}"
     
     begin
       result = yield
-      duration = Time.now - start_time
+      duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
       verbose "completed #{operation_name} in #{format_duration(duration)}"
       result
     rescue => error
-      duration = Time.now - start_time
+      duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
       verbose "failed #{operation_name} after #{format_duration(duration)}: #{error.class.name}: #{error.message}"
       raise
     end
   end
-  
-  private
   
   def self.format_duration(seconds)
     if seconds < 1.0

--- a/spec/command/publishing_spec.rb
+++ b/spec/command/publishing_spec.rb
@@ -591,6 +591,18 @@ describe 'Fig' do
         fig(%w<--update-if-missing --include foo/1.2.3 -- hello.bat>)[0].should ==
           'cheese'
       end
+
+      it 'warns on unused override' do
+        input = <<-END
+          config default
+            override unused-package/1.0.0
+            set WHATEVER=SOMETHING
+          end
+        END
+        out, err, exit_code = fig(%w<--update-if-missing>, input)
+
+        err.should =~ /Override "unused-package\/1\.0\.0".*was never used/
+      end
     end
   end
 end

--- a/spec/verbose_logging_spec.rb
+++ b/spec/verbose_logging_spec.rb
@@ -157,9 +157,9 @@ describe 'Fig::VerboseLogging' do
       Fig::VerboseLogging.enable_verbose!
       allow(Fig::Logging).to receive(:info?).and_return(true)
       
-      # Mock Time.now to control duration
-      start_time = Time.now
-      allow(Time).to receive(:now).and_return(start_time, start_time + 0.5)
+      # Mock Process.clock_gettime to control duration
+      start_time = 1000.0
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(start_time, start_time + 0.5)
       
       Fig::VerboseLogging.time_operation('test') { 'result' }
       

--- a/spec/verbose_logging_spec.rb
+++ b/spec/verbose_logging_spec.rb
@@ -93,100 +93,61 @@ describe 'Fig::VerboseLogging' do
     end
   end
 
-  describe '.log_dependency_resolution' do
-    it 'logs dependency resolution with proper indentation when verbose is enabled' do
+  describe '.verbose' do
+    it 'logs messages when verbose is enabled' do
       Fig::VerboseLogging.enable_verbose!
       allow(Fig::Logging).to receive(:info?).and_return(true)
       
-      Fig::VerboseLogging.log_dependency_resolution('mypackage', '1.0.0', 'default', 2)
+      Fig::VerboseLogging.verbose('test message')
       
       log_content = @log_output.string
-      expect(log_content).to include('[VERBOSE]     resolving dependency: mypackage/1.0.0:default')
+      expect(log_content).to include('[VERBOSE] test message')
     end
 
-    it 'skips logging for unnamed packages at root level' do
-      Fig::VerboseLogging.enable_verbose!
+    it 'logs messages when debug logging is enabled (even without verbose flag)' do
+      allow(Fig::Logging).to receive(:debug?).and_return(true)
       allow(Fig::Logging).to receive(:info?).and_return(true)
       
-      Fig::VerboseLogging.log_dependency_resolution(nil, nil, 'default', 0)
+      Fig::VerboseLogging.verbose('test message')
       
-      expect(@log_output.string).to be_empty
+      log_content = @log_output.string
+      expect(log_content).to include('[VERBOSE] test message')
     end
 
     it 'does not log when neither verbose nor debug is enabled' do
       allow(Fig::Logging).to receive(:debug?).and_return(false)
       allow(Fig::Logging).to receive(:info?).and_return(true)
       
-      Fig::VerboseLogging.log_dependency_resolution('mypackage', '1.0.0', 'default', 1)
+      Fig::VerboseLogging.verbose('test message')
       
       expect(@log_output.string).to be_empty
     end
-  end
 
-  describe '.log_repository_operation' do
-    it 'logs repository operations with details when verbose is enabled' do
+    it 'falls back to stderr when logging is disabled but verbose is enabled' do
       Fig::VerboseLogging.enable_verbose!
-      allow(Fig::Logging).to receive(:info?).and_return(true)
+      allow(Fig::Logging).to receive(:info?).and_return(false)
       
-      Fig::VerboseLogging.log_repository_operation('download', 'http://example.com/repo', '5 packages')
+      Fig::VerboseLogging.verbose('test message')
       
-      log_content = @log_output.string
-      expect(log_content).to include('[VERBOSE] repository download: http://example.com/repo (5 packages)')
+      stderr_content = @stderr_output.string
+      expect(stderr_content).to include('[VERBOSE] test message')
     end
   end
 
-  describe '.log_asset_operation' do
-    it 'logs asset operations with size formatting when verbose is enabled' do
+  describe '.should_log_verbose?' do
+    it 'returns true when verbose is enabled' do
       Fig::VerboseLogging.enable_verbose!
-      allow(Fig::Logging).to receive(:info?).and_return(true)
-      
-      Fig::VerboseLogging.log_asset_operation('downloading', '/path/to/file.tar.gz', 1536)
-      
-      log_content = @log_output.string
-      expect(log_content).to include('[VERBOSE] asset downloading: /path/to/file.tar.gz (1.5KB)')
-    end
-  end
-
-  describe '.log_override_applied' do
-    it 'logs override applications with proper indentation when verbose is enabled' do
-      Fig::VerboseLogging.enable_verbose!
-      allow(Fig::Logging).to receive(:info?).and_return(true)
-      
-      Fig::VerboseLogging.log_override_applied('mypackage', '1.0.0', '2.0.0', 1)
-      
-      log_content = @log_output.string
-      expect(log_content).to include('[VERBOSE]   override applied: mypackage/1.0.0 -> mypackage/2.0.0')
+      expect(Fig::VerboseLogging.should_log_verbose?).to be true
     end
 
-    it 'does not log when neither verbose nor debug is enabled' do
+    it 'returns true when debug logging is enabled' do
+      allow(Fig::Logging).to receive(:debug?).and_return(true)
+      expect(Fig::VerboseLogging.should_log_verbose?).to be true
+    end
+
+    it 'returns false when neither verbose nor debug is enabled' do
       allow(Fig::Logging).to receive(:debug?).and_return(false)
-      allow(Fig::Logging).to receive(:info?).and_return(true)
-      
-      Fig::VerboseLogging.log_override_applied('mypackage', '1.0.0', '2.0.0', 0)
-      
-      expect(@log_output.string).to be_empty
-    end
-  end
-
-  describe '.log_config_processing' do
-    it 'logs config processing for named packages when verbose is enabled' do
-      Fig::VerboseLogging.enable_verbose!
-      allow(Fig::Logging).to receive(:info?).and_return(true)
-      
-      Fig::VerboseLogging.log_config_processing('mypackage', '1.0.0', 'default')
-      
-      log_content = @log_output.string
-      expect(log_content).to include('[VERBOSE] processing config default for package mypackage/1.0.0')
-    end
-
-    it 'logs config processing for command-line packages when verbose is enabled' do
-      Fig::VerboseLogging.enable_verbose!
-      allow(Fig::Logging).to receive(:info?).and_return(true)
-      
-      Fig::VerboseLogging.log_config_processing(nil, nil, 'default')
-      
-      log_content = @log_output.string
-      expect(log_content).to include('[VERBOSE] processing config default for command-line package')
+      expect(Fig::VerboseLogging.should_log_verbose?).to be false
     end
   end
 

--- a/spec/verbose_logging_spec.rb
+++ b/spec/verbose_logging_spec.rb
@@ -1,0 +1,209 @@
+# coding: utf-8
+
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+
+require 'fig/verbose_logging'
+require 'fig/logging'
+
+describe 'Fig::VerboseLogging' do
+  before(:each) do
+    # Reset verbose state and capture output
+    Fig::VerboseLogging.class_variable_set(:@@verbose_enabled, false)
+    @log_output = StringIO.new
+    @stderr_output = StringIO.new
+    
+    allow(Fig::Logging).to receive(:info) do |message|
+      @log_output.puts(message) if Fig::Logging.info?
+    end
+    
+    allow($stderr).to receive(:puts) do |message|
+      @stderr_output.puts(message)
+    end
+  end
+
+  describe '.time_operation' do
+    it 'logs timing when verbose is enabled' do
+      Fig::VerboseLogging.enable_verbose!
+      allow(Fig::Logging).to receive(:info?).and_return(true)
+      
+      result = Fig::VerboseLogging.time_operation('test operation') do
+        sleep(0.01) # Small delay to ensure measurable time
+        'test result'
+      end
+      
+      expect(result).to eq('test result')
+      log_content = @log_output.string
+      expect(log_content).to include('[VERBOSE] starting test operation')
+      expect(log_content).to include('[VERBOSE] completed test operation in')
+      expect(log_content).to match(/\d+(\.\d+)?ms/)
+    end
+
+    it 'logs timing when debug logging is enabled (even without verbose flag)' do
+      allow(Fig::Logging).to receive(:debug?).and_return(true)
+      allow(Fig::Logging).to receive(:info?).and_return(true)
+      
+      result = Fig::VerboseLogging.time_operation('test operation') do
+        'test result'
+      end
+      
+      expect(result).to eq('test result')
+      log_content = @log_output.string
+      expect(log_content).to include('[VERBOSE] starting test operation')
+    end
+
+    it 'does not log when neither verbose nor debug is enabled' do
+      allow(Fig::Logging).to receive(:debug?).and_return(false)
+      allow(Fig::Logging).to receive(:info?).and_return(true)
+      
+      result = Fig::VerboseLogging.time_operation('test operation') do
+        'test result'
+      end
+      
+      expect(result).to eq('test result')
+      expect(@log_output.string).to be_empty
+    end
+
+    it 'falls back to stderr when logging is disabled but verbose is enabled' do
+      Fig::VerboseLogging.enable_verbose!
+      allow(Fig::Logging).to receive(:info?).and_return(false)
+      
+      result = Fig::VerboseLogging.time_operation('test operation') do
+        'test result'
+      end
+      
+      expect(result).to eq('test result')
+      stderr_content = @stderr_output.string
+      expect(stderr_content).to include('[VERBOSE] starting test operation')
+    end
+
+    it 'logs failure timing on exceptions' do
+      Fig::VerboseLogging.enable_verbose!
+      allow(Fig::Logging).to receive(:info?).and_return(true)
+      
+      expect do
+        Fig::VerboseLogging.time_operation('failing operation') do
+          raise StandardError, 'test error'
+        end
+      end.to raise_error(StandardError, 'test error')
+      
+      log_content = @log_output.string
+      expect(log_content).to include('[VERBOSE] starting failing operation')
+      expect(log_content).to include('[VERBOSE] failed failing operation after')
+      expect(log_content).to include('StandardError: test error')
+    end
+  end
+
+  describe '.log_dependency_resolution' do
+    it 'logs dependency resolution with proper indentation when verbose is enabled' do
+      Fig::VerboseLogging.enable_verbose!
+      allow(Fig::Logging).to receive(:info?).and_return(true)
+      
+      Fig::VerboseLogging.log_dependency_resolution('mypackage', '1.0.0', 'default', 2)
+      
+      log_content = @log_output.string
+      expect(log_content).to include('[VERBOSE]     resolving dependency: mypackage/1.0.0:default')
+    end
+
+    it 'skips logging for unnamed packages at root level' do
+      Fig::VerboseLogging.enable_verbose!
+      allow(Fig::Logging).to receive(:info?).and_return(true)
+      
+      Fig::VerboseLogging.log_dependency_resolution(nil, nil, 'default', 0)
+      
+      expect(@log_output.string).to be_empty
+    end
+
+    it 'does not log when neither verbose nor debug is enabled' do
+      allow(Fig::Logging).to receive(:debug?).and_return(false)
+      allow(Fig::Logging).to receive(:info?).and_return(true)
+      
+      Fig::VerboseLogging.log_dependency_resolution('mypackage', '1.0.0', 'default', 1)
+      
+      expect(@log_output.string).to be_empty
+    end
+  end
+
+  describe '.log_repository_operation' do
+    it 'logs repository operations with details when verbose is enabled' do
+      Fig::VerboseLogging.enable_verbose!
+      allow(Fig::Logging).to receive(:info?).and_return(true)
+      
+      Fig::VerboseLogging.log_repository_operation('download', 'http://example.com/repo', '5 packages')
+      
+      log_content = @log_output.string
+      expect(log_content).to include('[VERBOSE] repository download: http://example.com/repo (5 packages)')
+    end
+  end
+
+  describe '.log_asset_operation' do
+    it 'logs asset operations with size formatting when verbose is enabled' do
+      Fig::VerboseLogging.enable_verbose!
+      allow(Fig::Logging).to receive(:info?).and_return(true)
+      
+      Fig::VerboseLogging.log_asset_operation('downloading', '/path/to/file.tar.gz', 1536)
+      
+      log_content = @log_output.string
+      expect(log_content).to include('[VERBOSE] asset downloading: /path/to/file.tar.gz (1.5KB)')
+    end
+  end
+
+  describe '.log_override_applied' do
+    it 'logs override applications with proper indentation when verbose is enabled' do
+      Fig::VerboseLogging.enable_verbose!
+      allow(Fig::Logging).to receive(:info?).and_return(true)
+      
+      Fig::VerboseLogging.log_override_applied('mypackage', '1.0.0', '2.0.0', 1)
+      
+      log_content = @log_output.string
+      expect(log_content).to include('[VERBOSE]   override applied: mypackage/1.0.0 -> mypackage/2.0.0')
+    end
+
+    it 'does not log when neither verbose nor debug is enabled' do
+      allow(Fig::Logging).to receive(:debug?).and_return(false)
+      allow(Fig::Logging).to receive(:info?).and_return(true)
+      
+      Fig::VerboseLogging.log_override_applied('mypackage', '1.0.0', '2.0.0', 0)
+      
+      expect(@log_output.string).to be_empty
+    end
+  end
+
+  describe '.log_config_processing' do
+    it 'logs config processing for named packages when verbose is enabled' do
+      Fig::VerboseLogging.enable_verbose!
+      allow(Fig::Logging).to receive(:info?).and_return(true)
+      
+      Fig::VerboseLogging.log_config_processing('mypackage', '1.0.0', 'default')
+      
+      log_content = @log_output.string
+      expect(log_content).to include('[VERBOSE] processing config default for package mypackage/1.0.0')
+    end
+
+    it 'logs config processing for command-line packages when verbose is enabled' do
+      Fig::VerboseLogging.enable_verbose!
+      allow(Fig::Logging).to receive(:info?).and_return(true)
+      
+      Fig::VerboseLogging.log_config_processing(nil, nil, 'default')
+      
+      log_content = @log_output.string
+      expect(log_content).to include('[VERBOSE] processing config default for command-line package')
+    end
+  end
+
+  describe 'format helpers' do
+    it 'formats durations correctly' do
+      # Test private method via time_operation
+      Fig::VerboseLogging.enable_verbose!
+      allow(Fig::Logging).to receive(:info?).and_return(true)
+      
+      # Mock Time.now to control duration
+      start_time = Time.now
+      allow(Time).to receive(:now).and_return(start_time, start_time + 0.5)
+      
+      Fig::VerboseLogging.time_operation('test') { 'result' }
+      
+      log_content = @log_output.string
+      expect(log_content).to include('500.0ms') # 0.5 seconds formatted as milliseconds
+    end
+  end
+end


### PR DESCRIPTION
This adds two user-facing options:
* `--verbose` which logs information about what fig is doing at a level somewhere in between log levels of WARNING and DEBUG, and is independent of that logging.  It's meant primarily as a feedback mechanism to the user.  This feature was indirectly wished for by Jeff Bay and many others.
* `--suppress-warning-unused-override` which is pretty much the same as `--suppress-warning-unused-retrieve` except for `override`.  This feature was directly wished for by Matt Hellige.

Both of these features are things that users in #dev-fig have either directly or indirectly wished for, and weren't particularly difficult to implement.  Since most of the 2.x changes have been for internal benefit, it's nice to give something user-centric.