### PR TITLE
Improve user experience by making the artifactory protocol behave more like ftp protocol vis-a-vis authentication.

### DIFF
--- a/lib/fig/operating_system.rb
+++ b/lib/fig/operating_system.rb
@@ -88,7 +88,7 @@ class Fig::OperatingSystem
     @protocols['https'] = Fig::Protocol::HTTP.new
     @protocols['sftp'] = Fig::Protocol::SFTP.new
     @protocols['ssh']  = Fig::Protocol::SSH.new
-    @protocols['art'] = @protocols['artifactory'] = Fig::Protocol::Artifactory.new
+    @protocols['art'] = @protocols['artifactory'] = Fig::Protocol::Artifactory.new login
   end
 
   def list(dir)

--- a/lib/fig/protocol/artifactory.rb
+++ b/lib/fig/protocol/artifactory.rb
@@ -32,8 +32,20 @@ class Fig::Protocol::Artifactory
   # Default number of list entries to fetch on initial iteration
   INITIAL_LIST_FETCH_SIZE = 20000
 
-  def initialize
+  def initialize(login)
+    @login = login
     initialize_netrc
+  end
+
+  # like ftp's ftp_login
+  def artifactory_auth(client_config, host, prompt_for_login)
+    if @login
+      auth = get_authentication_for(host, prompt_for_login)
+      if auth
+        client_config[:username] = auth.username
+        client_config[:password] = auth.password
+      end
+    end
   end
 
   # must return a list of strings in the form <package_name>/<version>
@@ -47,12 +59,8 @@ class Fig::Protocol::Artifactory
       parse_uri(uri) => { repo_key:, base_endpoint: }
       
       # Create Artifactory client instance
-      authentication = get_authentication_for(uri.host, :prompt_for_login)
       client_config = { endpoint: base_endpoint }
-      if authentication
-        client_config[:username] = authentication.username
-        client_config[:password] = authentication.password
-      end
+      artifactory_auth(client_config, uri.host, :prompt_for_login)
       client = ::Artifactory::Client.new(client_config)
 
       # Use Artifactory browser API to list directories at repo root
@@ -85,9 +93,11 @@ class Fig::Protocol::Artifactory
     uri = httpify_uri(art_uri)
 
     # Log equivalent curl command for debugging
-    authentication = get_authentication_for(uri.host, prompt_for_login)
-    if authentication
-      Fig::Logging.debug("Equivalent curl: curl -u #{authentication.username}:*** -o '#{path}' '#{uri}'")
+    client_config = { endpoint: art_uri }
+    artifactory_auth(client_config, uri.host, prompt_for_login)
+    
+    if client_config[:username]
+      Fig::Logging.debug("Equivalent curl: curl -u #{client_config[:username]}:*** -o '#{path}' '#{uri}'")
     else
       Fig::Logging.debug("Equivalent curl: curl -o '#{path}' '#{uri}'")
     end
@@ -96,6 +106,7 @@ class Fig::Protocol::Artifactory
       file.binmode
 
       begin
+        # TODO seems we should use client_config to do http auth if provided?
         download_via_http_get(uri.to_s, file)
       rescue SystemCallError => error
         Fig::Logging.debug error.message
@@ -115,20 +126,16 @@ class Fig::Protocol::Artifactory
     begin
       parse_uri(uri) => { repo_key:, base_endpoint:, target_path: }
 
+      client_config = { endpoint: base_endpoint }
+      artifactory_auth(client_config, uri.host, :prompt_for_login)
+      
       # Configure Artifactory gem globally - unlike other methods that can use client instances,
       # the artifact.upload() method ignores the client: parameter and only uses global config.
       # This is a limitation of the artifactory gem's upload implementation.
-      authentication = get_authentication_for(uri.host, :prompt_for_login)
-      ::Artifactory.configure do |config|
-        config.endpoint = base_endpoint
-        if authentication
-          config.username = authentication.username
-          config.password = authentication.password
-        end
-      end
+      ::Artifactory.configure{ |c| client_config.each{|k,v| c.public_send("#{k}=",v)} } # thx o4!
 
       # Log equivalent curl command for debugging
-      if authentication
+      if client_config[:username]
         Fig::Logging.debug("Equivalent curl: curl -u #{authentication.username}:*** -T '#{local_file}' '#{uri}'")
       else
         Fig::Logging.debug("Equivalent curl: curl -T '#{local_file}' '#{uri}'")
@@ -163,12 +170,8 @@ class Fig::Protocol::Artifactory
 
 
       # Create Artifactory client instance (same as upload method)
-      authentication = get_authentication_for(uri.host, prompt_for_login)
       client_config = { endpoint: base_endpoint }
-      if authentication
-        client_config[:username] = authentication.username
-        client_config[:password] = authentication.password
-      end
+      artifactory_auth(client_config, uri.host, :prompt_for_login)
       client = ::Artifactory::Client.new(client_config)
       
       # use storage api instead of search - more reliable for virtual repos

--- a/lib/fig/protocol/artifactory.rb
+++ b/lib/fig/protocol/artifactory.rb
@@ -136,7 +136,7 @@ class Fig::Protocol::Artifactory
 
       # Log equivalent curl command for debugging
       if client_config[:username]
-        Fig::Logging.debug("Equivalent curl: curl -u #{authentication.username}:*** -T '#{local_file}' '#{uri}'")
+        Fig::Logging.debug("Equivalent curl: curl -u #{client_config[:username]}:*** -T '#{local_file}' '#{uri}'")
       else
         Fig::Logging.debug("Equivalent curl: curl -T '#{local_file}' '#{uri}'")
       end

--- a/lib/fig/version.rb
+++ b/lib/fig/version.rb
@@ -1,5 +1,8 @@
 # coding: utf-8
 
+# version format:
+# pre-release: M.m.p-<pretag>.X eg,  2.0.0-alpha.23
+# release: M.m.p eg, 2.0.0
 module Fig
-  VERSION = '2.0.0'.freeze
+  VERSION = '2.1.0-alpha.1'.freeze
 end

--- a/spec/protocol/artifactory_spec.rb
+++ b/spec/protocol/artifactory_spec.rb
@@ -444,6 +444,42 @@ describe Fig::Protocol::Artifactory do
         artifactory.download(uri, path, prompt_for_login)
       end
     end
+
+    context 'HTTP authentication' do
+      let(:artifactory) { Fig::Protocol::Artifactory.new true }
+      let(:mock_http) { double('Net::HTTP') }
+      let(:mock_request) { double('Net::HTTP::Get') }
+      let(:mock_response) { double('Net::HTTPSuccess', body: 'file content') }
+
+      before do
+        allow(artifactory).to receive(:get_authentication_for).and_return(mock_auth)
+        allow(Net::HTTP).to receive(:new).and_return(mock_http)
+        allow(Net::HTTP::Get).to receive(:new).and_return(mock_request)
+        allow(mock_http).to receive(:use_ssl=)
+        allow(mock_http).to receive(:request).and_return(mock_response)
+        allow(mock_response).to receive(:is_a?).with(Net::HTTPSuccess).and_return(true)
+        allow(mock_response).to receive(:is_a?).with(Net::HTTPRedirection).and_return(false)
+        allow(mock_file).to receive(:write)
+      end
+
+      it 'sends HTTP basic auth headers when credentials are available' do
+        pending "download_via_http_get needs to be updated to support HTTP authentication"
+        
+        expect(mock_request).to receive(:basic_auth).with('testuser', 'testpass')
+        artifactory.download(uri, path, prompt_for_login)
+      end
+
+      it 'successfully downloads when server requires authentication' do
+        pending "download_via_http_get needs to be updated to support HTTP authentication"
+        
+        allow(mock_request).to receive(:basic_auth)
+        expect(mock_http).to receive(:request).with(mock_request).and_return(mock_response)
+        expect(mock_file).to receive(:write).with('file content')
+        
+        result = artifactory.download(uri, path, prompt_for_login)
+        expect(result).to be true
+      end
+    end
   end
 
   describe '#httpify_uri' do


### PR DESCRIPTION
The ftp fig protocol does not require login information to operate as long as the target repository permits anonymous access.

Artifactory repositories can also be set up for anonymous access, and a common use-case is to use fig to acquire packages/dependencies from anonymous-read-only repos.  This PR relaxes the requirement for the user to supply credentials when using fig with artifactory.