### PR TITLE
Fix publish failure

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -233,18 +233,12 @@ jobs:
           name: fig
           path: pkg/
 
-      - name: Get gem version
-        id: gem-version
-        run: |
-          GEM_VERSION=$(ls pkg/*.gem | sed 's/.*-\([0-9.]\+\)\.gem/\1/')
-          echo "version=${GEM_VERSION}" >> "$GITHUB_OUTPUT"
-
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
           files: pkg/*.gem
-          name: Release v${{ steps.gem-version.outputs.version }}
-          tag_name: v${{ needs.auto-tag.outputs.version }}
+          name: Release v${{ needs.auto-tag.outputs.new_version }}
+          tag_name: v${{ needs.auto-tag.outputs.new_version }}
           draft: false
           prerelease: false
           generate_release_notes: true

--- a/lib/fig/command/action/publish.rb
+++ b/lib/fig/command/action/publish.rb
@@ -30,7 +30,7 @@ class Fig::Command::Action::Publish
 
     package_description =
       Fig::PackageDescriptor.format(@descriptor.name, @descriptor.version, nil)
-    if @execution_context.repository.list_remote_packages.include?(
+    if @execution_context.repository.list_remote_packages(:upload).include?(
       package_description
     )
       Fig::Logging.info "#{@descriptor.to_string()} has already been published."

--- a/lib/fig/repository.rb
+++ b/lib/fig/repository.rb
@@ -77,13 +77,19 @@ class Fig::Repository
     return results
   end
 
-  def list_remote_packages
+  def list_remote_packages(url = :download)
+    actual =
+      case url
+      when :download then remote_download_url
+      when :upload   then remote_upload_url
+      else                url
+      end
     check_remote_repository_format()
 
-    Fig::VerboseLogging.time_operation("listing remote packages from #{remote_download_url()}") do
-      paths = @operating_system.download_list(remote_download_url())
+    Fig::VerboseLogging.time_operation("listing remote packages from #{actual}") do
+      paths = @operating_system.download_list(actual)
       filtered_paths = paths.reject { |path| path =~ %r< ^ #{METADATA_SUBDIRECTORY} / >xs }
-      Fig::VerboseLogging.verbose "found #{filtered_paths.size} packages at #{remote_download_url()}"
+      Fig::VerboseLogging.verbose "found #{filtered_paths.size} packages at #{actual}"
       filtered_paths
     end
   end


### PR DESCRIPTION
This fixes [an artifactory/split repo model publish failure](https://git.drwholdings.com/infrastructure-development/fig-packages/actions/runs/3998004/job/11905632#step:5:36863) that doesn't exist in the unitary model: the `--publish` command checks to see if the package is already in the current repo list--which, in split-repo model happens to be _the download repo_.  The change here is for publish to check the content of _the upload repo_.

I think this solution is appropriate in this case.  However, we might also consider adding a **warning** level check on the download repo as well, since for the artifactory repository design, a pre-existing presence of the same package on the download side might end up occluding a download of the package the user is trying to publish.  Ideally, there'd be a way to figure out which of the constituent repositories was actually contributing the package, but AFAIK artifactory doesn't offer that feature.